### PR TITLE
fix: don't rely on `std.time.microTimestamp()` for accurate statistics

### DIFF
--- a/src/vaxis.zig
+++ b/src/vaxis.zig
@@ -80,6 +80,7 @@ pub fn Vaxis(comptime T: type) type {
         // statistics
         renders: usize = 0,
         render_dur: i128 = 0,
+        render_timer: std.time.Timer,
 
         /// Initialize Vaxis with runtime options
         pub fn init(_: Options) !Self {
@@ -88,6 +89,7 @@ pub fn Vaxis(comptime T: type) type {
                 .tty = null,
                 .screen = .{},
                 .screen_last = .{},
+                .render_timer = try std.time.Timer.start(),
             };
         }
 
@@ -252,9 +254,9 @@ pub fn Vaxis(comptime T: type) type {
         pub fn render(self: *Self) !void {
             var tty = self.tty orelse return;
             self.renders += 1;
-            const timer_start = std.time.microTimestamp();
+            self.render_timer.reset();
             defer {
-                self.render_dur += std.time.microTimestamp() - timer_start;
+                self.render_dur += self.render_timer.read() / std.time.ns_per_us;
             }
 
             defer self.refresh = false;


### PR DESCRIPTION
I don't know the extent to which you care about accuracy for rendering statistics. I found when working on seamstress that the `timestamp` calls in `std.time` were so unreliable as to be unusable, sometimes reporting negative time deltas within a single
function. `std.time.Timer`, on the other hand, has been rock-solid in my experience.