### PR TITLE
vaxis: export Parser, Tty and getWinsize for applications that cannot use Loop

### DIFF
--- a/src/Tty.zig
+++ b/src/Tty.zig
@@ -278,7 +278,7 @@ pub const Winsize = struct {
     y_pixel: usize,
 };
 
-fn getWinsize(fd: posix.fd_t) !Winsize {
+pub fn getWinsize(fd: posix.fd_t) !Winsize {
     var winsize = posix.winsize{
         .ws_row = 0,
         .ws_col = 0,

--- a/src/main.zig
+++ b/src/main.zig
@@ -14,8 +14,10 @@ pub const Image = @import("Image.zig");
 pub const Mouse = @import("Mouse.zig");
 pub const Screen = @import("Screen.zig");
 pub const AllocatingScreen = @import("InternalScreen.zig");
-pub const Winsize = @import("Tty.zig").Winsize;
+pub const Parser = @import("Parser.zig");
+pub const Tty = @import("Tty.zig");
 pub const Window = @import("Window.zig");
+pub const Winsize = Tty.Winsize;
 
 pub const widgets = @import("widgets.zig");
 pub const gwidth = @import("gwidth.zig");


### PR DESCRIPTION
This allows [neurocyte/flow](https://github.com/neurocyte/flow) to use it's own event loop with libvaxis.