### PR TITLE
vaxis: add osc52 copy/paste support

### DIFF
--- a/examples/cli.zig
+++ b/examples/cli.zig
@@ -19,7 +19,7 @@ pub fn main() !void {
 
     var loop: vaxis.Loop(Event) = .{ .vaxis = &vx };
 
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
 
     try vx.queryTerminal();

--- a/examples/image.zig
+++ b/examples/image.zig
@@ -23,7 +23,7 @@ pub fn main() !void {
 
     var loop: vaxis.Loop(Event) = .{ .vaxis = &vx };
 
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
 
     try vx.enterAltScreen();

--- a/examples/main.zig
+++ b/examples/main.zig
@@ -22,7 +22,7 @@ pub fn main() !void {
 
     // Start the read loop. This puts the terminal in raw mode and begins
     // reading user input
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
 
     // Optionally enter the alternate screen

--- a/examples/nvim.zig
+++ b/examples/nvim.zig
@@ -29,7 +29,7 @@ pub fn main() !void {
 
     var loop: vaxis.Loop(Event) = .{ .vaxis = &vx };
 
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
 
     // Optionally enter the alternate screen

--- a/examples/pathological.zig
+++ b/examples/pathological.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
 
     var loop: vaxis.Loop(Event) = .{ .vaxis = &vx };
 
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
     try vx.enterAltScreen();
     try vx.queryTerminal();

--- a/examples/shell.zig
+++ b/examples/shell.zig
@@ -19,7 +19,7 @@ pub fn main() !void {
 
     var loop: vaxis.Loop(Event) = .{ .vaxis = &vx };
 
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
 
     try vx.queryTerminal();

--- a/examples/table.zig
+++ b/examples/table.zig
@@ -32,7 +32,7 @@ pub fn main() !void {
         winsize: vaxis.Winsize,
     }) = .{ .vaxis = &vx };
 
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
     try vx.enterAltScreen();
     try vx.queryTerminal();

--- a/examples/text_input.zig
+++ b/examples/text_input.zig
@@ -42,7 +42,7 @@ pub fn main() !void {
 
     // Start the read loop. This puts the terminal in raw mode and begins
     // reading user input
-    try loop.run();
+    try loop.run(alloc);
     defer loop.stop();
 
     // Optionally enter the alternate screen
@@ -85,7 +85,7 @@ pub fn main() !void {
                     loop.stop();
                     var child = std.process.Child.init(&.{"nvim"}, alloc);
                     _ = try child.spawnAndWait();
-                    try loop.run();
+                    try loop.run(alloc);
                     try vx.enterAltScreen();
                     vx.queueRefresh();
                 } else if (key.matches(vaxis.Key.enter, .{})) {

--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -25,6 +25,7 @@ pub fn Loop(comptime T: type) type {
                 T,
                 self,
                 &self.vaxis.unicode.grapheme_data,
+                self.vaxis.opts.system_clipboard_allocator,
             });
         }
 

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -105,6 +105,8 @@ pub const osc8_clear = "\x1b]8;;\x1b\\";
 pub const osc9_notify = "\x1b]9;{s}\x1b\\";
 pub const osc777_notify = "\x1b]777;notify;{s};{s}\x1b\\";
 pub const osc22_mouse_shape = "\x1b]22;{s}\x1b\\";
+pub const osc52_clipboard_copy = "\x1b]52;c;{s}\x1b\\";
+pub const osc52_clipboard_request = "\x1b]52;c;?\x1b\\";
 
 // Kitty graphics
 pub const kitty_graphics_clear = "\x1b_Ga=d\x1b\\";

--- a/src/event.zig
+++ b/src/event.zig
@@ -8,8 +8,9 @@ pub const Event = union(enum) {
     mouse: Mouse,
     focus_in,
     focus_out,
-    paste_start,
-    paste_end,
+    paste_start, // bracketed paste start
+    paste_end, // bracketed paste end
+    paste: []const u8, // osc 52 paste, caller must free
 
     // these are delivered as discovered terminal capabilities
     cap_kitty_keyboard,


### PR DESCRIPTION
I was not sure where to get an allocator for the pasted text, so I stole the grapheme allocator. Passing an allocator to parse is probably preferrable, but that felt like a large API change so I thought I'd let you decide.