### PR TITLE
Add sgr-pixel detection and coordinate to offset translation

### DIFF
--- a/examples/pause_tui.zig
+++ b/examples/pause_tui.zig
@@ -58,7 +58,7 @@ pub fn main() !void {
     // _always_ be called, but is left to the application to decide when
     try vx.queryTerminal();
 
-    try vx.setMouseMode(.cells);
+    try vx.setMouseMode(true);
 
     // The main event loop. Vaxis provides a thread safe, blocking, buffered
     // queue which can serve as the primary event queue for an application

--- a/examples/text_input.zig
+++ b/examples/text_input.zig
@@ -60,7 +60,7 @@ pub fn main() !void {
     // _always_ be called, but is left to the application to decide when
     try vx.queryTerminal();
 
-    try vx.setMouseMode(.pixels);
+    try vx.setMouseMode(true);
 
     // The main event loop. Vaxis provides a thread safe, blocking, buffered
     // queue which can serve as the primary event queue for an application

--- a/src/Mouse.zig
+++ b/src/Mouse.zig
@@ -1,12 +1,6 @@
 /// A mouse event
 pub const Mouse = @This();
 
-pub const ReportingMode = enum {
-    off,
-    cells,
-    pixels,
-};
-
 pub const Shape = enum {
     default,
     text,
@@ -47,6 +41,8 @@ pub const Type = enum {
 
 col: usize,
 row: usize,
+xoffset: usize = 0,
+yoffset: usize = 0,
 button: Button,
 mods: Modifiers,
 type: Type,

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -260,8 +260,8 @@ pub fn parse(self: *Parser, input: []const u8, paste_allocator: ?std.mem.Allocat
                                 const shift = seq.params[0] & mouse_bits.shift > 0;
                                 const alt = seq.params[0] & mouse_bits.alt > 0;
                                 const ctrl = seq.params[0] & mouse_bits.ctrl > 0;
-                                const col: usize = seq.params[1] - 1;
-                                const row: usize = seq.params[2] - 1;
+                                const col: usize = if(seq.params[1] > 0) seq.params[1] - 1 else 0;
+                                const row: usize = if(seq.params[2] > 0) seq.params[2] - 1 else 0;
 
                                 const mouse = Mouse{
                                     .button = button,

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -404,6 +404,9 @@ pub fn parse(self: *Parser, input: []const u8, paste_allocator: ?std.mem.Allocat
                                 // 3: permanently set
                                 // 4: permanently reset
                                 switch (seq.params[0]) {
+                                    1016 => {
+                                        return .{ .event = .cap_sgr_pixels, .n = i + 1 };
+                                    },
                                     2027 => {
                                         switch (seq.params[1]) {
                                             0, 4 => return .{ .event = null, .n = i + 1 },

--- a/src/Tty.zig
+++ b/src/Tty.zig
@@ -31,6 +31,7 @@ state: struct {
     kitty_keyboard: bool = false,
     bracketed_paste: bool = false,
     mouse: bool = false,
+    pixel_mouse: bool = false,
     cursor: struct {
         row: usize = 0,
         col: usize = 0,
@@ -179,7 +180,7 @@ pub fn run(
                 },
                 .mouse => |mouse| {
                     if (@hasField(Event, "mouse")) {
-                        loop.postEvent(.{ .mouse = mouse });
+                        loop.postEvent(.{ .mouse = loop.vaxis.translateMouse(mouse) });
                     }
                 },
                 .focus_in => {
@@ -228,6 +229,10 @@ pub fn run(
                     log.info("unicode capability detected", .{});
                     loop.vaxis.caps.unicode = .unicode;
                     loop.vaxis.screen.width_method = .unicode;
+                },
+                .cap_sgr_pixels => {
+                    log.info("pixel mouse capability detected", .{});
+                    loop.vaxis.caps.sgr_pixels = true;
                 },
                 .cap_da1 => {
                     std.Thread.Futex.wake(&loop.vaxis.query_futex, 10);

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -4,6 +4,7 @@ pub const tertiary_device_attrs = "\x1b[=c";
 pub const device_status_report = "\x1b[5n";
 pub const xtversion = "\x1b[>0q";
 pub const decrqm_focus = "\x1b[?1004$p";
+pub const decrqm_sgr_pixels = "\x1b[?1016$p";
 pub const decrqm_sync = "\x1b[?2026$p";
 pub const decrqm_unicode = "\x1b[?2027$p";
 pub const decrqm_color_theme = "\x1b[?2031$p";

--- a/src/event.zig
+++ b/src/event.zig
@@ -16,6 +16,7 @@ pub const Event = union(enum) {
     cap_kitty_keyboard,
     cap_kitty_graphics,
     cap_rgb,
+    cap_sgr_pixels,
     cap_unicode,
     cap_da1,
 };


### PR DESCRIPTION
This detects support for pixel mouse mode so it can be enabled only if supported.

This also translates pixel coordinates to something more compatible with plaine cell coordinates. This make it much easier to write applications that support both.

Also a commit for a crash on zero mouse reports.