### PR TITLE
tty: do not close /dev/tty on macos

### DIFF
--- a/src/Tty.zig
+++ b/src/Tty.zig
@@ -73,7 +73,8 @@ pub fn deinit(self: *Tty) void {
     posix.tcsetattr(self.fd, .FLUSH, self.termios) catch |err| {
         log.err("couldn't restore terminal: {}", .{err});
     };
-    posix.close(self.fd);
+    if (builtin.os.tag != .macos) // closing /dev/tty may block indefinitely on macos
+        posix.close(self.fd);
 }
 
 /// stops the run loop


### PR DESCRIPTION
Attempting to close /dev/tty may block indefinitely on macos if another thread is already blocked on a read operation. As there is no practical use for closing /dev/tty on exit besides unblocking other threads (which does not work on macos anyway) we can just skip the close call.