### PR TITLE
fix: (build.zig.zon) tty.zig not capitalized

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,7 +33,7 @@
         "src/Mouse.zig",
         "src/Parser.zig",
         "src/Screen.zig",
-        "src/Tty.zig",
+        "src/tty.zig",
         "src/Unicode.zig",
         "src/Vaxis.zig",
         "src/Window.zig",


### PR DESCRIPTION
on my machine, because `build.zig.zon` is case sensitive, `tty.zig` was not making it into the package. this fixes that and allows compilation to proceed.