### PR TITLE
Introduce new standard widgets

### DIFF
--- a/src/widgets.zig
+++ b/src/widgets.zig
@@ -8,3 +8,4 @@ pub const TextInput = @import("widgets/TextInput.zig");
 pub const nvim = @import("widgets/nvim.zig");
 pub const ScrollView = @import("widgets/ScrollView.zig");
 pub const LineNumbers = @import("widgets/LineNumbers.zig");
+pub const TextView = @import("widgets/TextView.zig");

--- a/src/widgets.zig
+++ b/src/widgets.zig
@@ -6,3 +6,4 @@ pub const Scrollbar = @import("widgets/Scrollbar.zig");
 pub const Table = @import("widgets/Table.zig");
 pub const TextInput = @import("widgets/TextInput.zig");
 pub const nvim = @import("widgets/nvim.zig");
+pub const ScrollView = @import("widgets/ScrollView.zig");

--- a/src/widgets.zig
+++ b/src/widgets.zig
@@ -9,3 +9,4 @@ pub const nvim = @import("widgets/nvim.zig");
 pub const ScrollView = @import("widgets/ScrollView.zig");
 pub const LineNumbers = @import("widgets/LineNumbers.zig");
 pub const TextView = @import("widgets/TextView.zig");
+pub const CodeView = @import("widgets/CodeView.zig");

--- a/src/widgets.zig
+++ b/src/widgets.zig
@@ -7,3 +7,4 @@ pub const Table = @import("widgets/Table.zig");
 pub const TextInput = @import("widgets/TextInput.zig");
 pub const nvim = @import("widgets/nvim.zig");
 pub const ScrollView = @import("widgets/ScrollView.zig");
+pub const LineNumbers = @import("widgets/LineNumbers.zig");

--- a/src/widgets/CodeView.zig
+++ b/src/widgets/CodeView.zig
@@ -1,0 +1,112 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+const ScrollView = vaxis.widgets.ScrollView;
+const LineNumbers = vaxis.widgets.LineNumbers;
+
+pub const DrawOptions = struct {
+    highlighted_line: usize = 0,
+    draw_line_numbers: bool = true,
+    indentation: usize = 0,
+};
+
+pub const Buffer = vaxis.widgets.TextView.Buffer;
+
+scroll_view: ScrollView = .{ .vertical_scrollbar = null },
+highlighted_style: vaxis.Style = .{ .bg = .{ .index = 0 } },
+indentation_cell: vaxis.Cell = .{
+    .char = .{
+        .grapheme = "┆",
+        .width = 1,
+    },
+    .style = .{ .dim = true },
+},
+
+pub fn input(self: *@This(), key: vaxis.Key) void {
+    self.scroll_view.input(key);
+}
+
+pub fn draw(self: *@This(), win: vaxis.Window, buffer: Buffer, opts: DrawOptions) void {
+    const pad_left: usize = if (opts.draw_line_numbers) LineNumbers.numDigits(buffer.rows) +| 1 else 0;
+    self.scroll_view.draw(win, .{
+        .cols = buffer.cols + pad_left,
+        .rows = buffer.rows,
+    });
+    if (opts.draw_line_numbers) {
+        var nl: LineNumbers = .{
+            .highlighted_line = opts.highlighted_line,
+            .num_lines = buffer.rows +| 1,
+        };
+        nl.draw(win.child(.{
+            .x_off = 0,
+            .y_off = 0,
+            .width = .{ .limit = pad_left },
+            .height = .{ .limit = win.height },
+        }), self.scroll_view.scroll.y);
+    }
+    self.drawCode(win.child(.{ .x_off = pad_left }), buffer, opts);
+}
+
+fn drawCode(self: *@This(), win: vaxis.Window, buffer: Buffer, opts: DrawOptions) void {
+    const Pos = struct { x: usize = 0, y: usize = 0 };
+    var pos: Pos = .{};
+    var byte_index: usize = 0;
+    var is_indentation = true;
+    const bounds = self.scroll_view.bounds(win);
+    for (buffer.grapheme.items(.len), buffer.grapheme.items(.offset), 0..) |g_len, g_offset, index| {
+        if (bounds.above(pos.y)) {
+            break;
+        }
+
+        const cluster = buffer.content.items[g_offset..][0..g_len];
+        defer byte_index += cluster.len;
+
+        if (std.mem.eql(u8, cluster, "\n")) {
+            if (index == buffer.grapheme.len - 1) {
+                break;
+            }
+            pos.y += 1;
+            pos.x = 0;
+            is_indentation = true;
+            continue;
+        } else if (bounds.below(pos.y)) {
+            continue;
+        }
+
+        const highlighted_line = pos.y +| 1 == opts.highlighted_line;
+        var style: vaxis.Style = if (highlighted_line) self.highlighted_style else .{};
+
+        if (buffer.style_map.get(byte_index)) |meta| {
+            const tmp = style.bg;
+            style = buffer.style_list.items[meta];
+            style.bg = tmp;
+        }
+
+        const width = win.gwidth(cluster);
+        defer pos.x +|= width;
+
+        if (!bounds.colInside(pos.x)) {
+            continue;
+        }
+
+        if (opts.indentation > 0 and !std.mem.eql(u8, cluster, " ")) {
+            is_indentation = false;
+        }
+
+        if (is_indentation and opts.indentation > 0 and pos.x % opts.indentation == 0) {
+            var cell = self.indentation_cell;
+            cell.style.bg = style.bg;
+            self.scroll_view.writeCell(win, pos.x, pos.y, cell);
+        } else {
+            self.scroll_view.writeCell(win, pos.x, pos.y, .{
+                .char = .{ .grapheme = cluster, .width = width },
+                .style = style,
+            });
+        }
+
+        if (highlighted_line) {
+            for (pos.x +| width..bounds.x2) |x| {
+                self.scroll_view.writeCell(win, x, pos.y, .{ .style = style });
+            }
+        }
+    }
+}

--- a/src/widgets/LineNumbers.zig
+++ b/src/widgets/LineNumbers.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const digits = "0123456789";
+
+num_lines: usize = std.math.maxInt(usize),
+highlighted_line: usize = 0,
+style: vaxis.Style = .{ .dim = true },
+highlighted_style: vaxis.Style = .{ .dim = true, .bg = .{ .index = 0 } },
+
+pub fn extractDigit(v: usize, n: usize) usize {
+    return (v / (std.math.powi(usize, 10, n) catch unreachable)) % 10;
+}
+
+pub fn numDigits(v: usize) usize {
+    return switch (v) {
+        0...9 => 1,
+        10...99 => 2,
+        100...999 => 3,
+        1000...9999 => 4,
+        10000...99999 => 5,
+        100000...999999 => 6,
+        1000000...9999999 => 7,
+        10000000...99999999 => 8,
+        else => 0,
+    };
+}
+
+pub fn draw(self: @This(), win: vaxis.Window, y_scroll: usize) void {
+    for (1 + y_scroll..self.num_lines) |line| {
+        if (line - 1 >= y_scroll +| win.height) {
+            break;
+        }
+        const highlighted = line == self.highlighted_line;
+        const num_digits = numDigits(line);
+        for (0..num_digits) |i| {
+            const digit = extractDigit(line, i);
+            win.writeCell(win.width -| (i + 2), line -| (y_scroll +| 1), .{
+                .char = .{
+                    .width = 1,
+                    .grapheme = digits[digit .. digit + 1],
+                },
+                .style = if (highlighted) self.highlighted_style else self.style,
+            });
+        }
+        if (highlighted) {
+            for (num_digits + 1..win.width) |i| {
+                win.writeCell(i, line -| (y_scroll +| 1), .{
+                    .style = if (highlighted) self.highlighted_style else self.style,
+                });
+            }
+        }
+    }
+}

--- a/src/widgets/ScrollView.zig
+++ b/src/widgets/ScrollView.zig
@@ -1,0 +1,129 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+pub const Scroll = struct {
+    x: usize = 0,
+    y: usize = 0,
+
+    pub fn restrictTo(self: *@This(), w: usize, h: usize) void {
+        self.x = @min(self.x, w);
+        self.y = @min(self.y, h);
+    }
+};
+
+pub const VerticalScrollbar = struct {
+    character: vaxis.Cell.Character = .{ .grapheme = "▐", .width = 1 },
+    fg: vaxis.Style = .{},
+    bg: vaxis.Style = .{ .fg = .{ .index = 8 } },
+};
+
+scroll: Scroll = .{},
+vertical_scrollbar: ?VerticalScrollbar = .{},
+
+/// Standard input mappings.
+/// It is not neccessary to use this, you can set `scroll` manually.
+pub fn input(self: *@This(), key: vaxis.Key) void {
+    if (key.matches(vaxis.Key.right, .{})) {
+        self.scroll.x +|= 1;
+    } else if (key.matches(vaxis.Key.right, .{ .shift = true })) {
+        self.scroll.x +|= 32;
+    } else if (key.matches(vaxis.Key.left, .{})) {
+        self.scroll.x -|= 1;
+    } else if (key.matches(vaxis.Key.left, .{ .shift = true })) {
+        self.scroll.x -|= 32;
+    } else if (key.matches(vaxis.Key.up, .{})) {
+        self.scroll.y -|= 1;
+    } else if (key.matches(vaxis.Key.page_up, .{})) {
+        self.scroll.y -|= 32;
+    } else if (key.matches(vaxis.Key.down, .{})) {
+        self.scroll.y +|= 1;
+    } else if (key.matches(vaxis.Key.page_down, .{})) {
+        self.scroll.y +|= 32;
+    } else if (key.matches(vaxis.Key.end, .{})) {
+        self.scroll.y = std.math.maxInt(usize);
+    } else if (key.matches(vaxis.Key.home, .{})) {
+        self.scroll.y = 0;
+    }
+}
+
+/// Must be called before doing any `writeCell` calls.
+pub fn draw(self: *@This(), parent: vaxis.Window, content_size: struct {
+    cols: usize,
+    rows: usize,
+}) void {
+    var content_cols = content_size.cols;
+    if (self.vertical_scrollbar) |opts| {
+        const vbar: vaxis.widgets.Scrollbar = .{
+            .character = opts.character,
+            .style = opts.fg,
+            .total = content_size.rows,
+            .view_size = parent.height,
+            .top = self.scroll.y,
+        };
+        const bg = parent.child(.{
+            .x_off = parent.width -| opts.character.width,
+            .width = .{ .limit = opts.character.width },
+            .height = .{ .limit = parent.height },
+        });
+        bg.fill(.{ .char = opts.character, .style = opts.bg });
+        vbar.draw(bg);
+        content_cols +|= 1;
+    }
+    const max_scroll_x = content_cols -| parent.width;
+    const max_scroll_y = content_size.rows -| parent.height;
+    self.scroll.restrictTo(max_scroll_x, max_scroll_y);
+}
+
+pub const BoundingBox = struct {
+    x1: usize,
+    y1: usize,
+    x2: usize,
+    y2: usize,
+
+    pub inline fn below(self: @This(), row: usize) bool {
+        return row < self.y1;
+    }
+
+    pub inline fn above(self: @This(), row: usize) bool {
+        return row >= self.y2;
+    }
+
+    pub inline fn rowInside(self: @This(), row: usize) bool {
+        return row >= self.y1 and row < self.y2;
+    }
+
+    pub inline fn colInside(self: @This(), col: usize) bool {
+        return col >= self.x1 and col < self.x2;
+    }
+
+    pub inline fn inside(self: @This(), col: usize, row: usize) bool {
+        return self.rowInside(row) and self.colInside(col);
+    }
+};
+
+/// Boundary of the content, useful for culling to improve draw performance.
+pub fn bounds(self: *@This(), parent: vaxis.Window) BoundingBox {
+    const right_pad: usize = if (self.vertical_scrollbar != null) 1 else 0;
+    return .{
+        .x1 = self.scroll.x,
+        .y1 = self.scroll.y,
+        .x2 = self.scroll.x +| parent.width -| right_pad,
+        .y2 = self.scroll.y +| parent.height,
+    };
+}
+
+/// Use this function instead of `Window.writeCell` to draw your cells and they will magically scroll.
+pub fn writeCell(self: *@This(), parent: vaxis.Window, col: usize, row: usize, cell: vaxis.Cell) void {
+    const b = self.bounds(parent);
+    if (!b.inside(col, row)) return;
+    const win = parent.child(.{ .width = .{ .limit = b.x2 - b.x1 }, .height = .{ .limit = b.y2 - b.y1 } });
+    win.writeCell(col -| self.scroll.x, row -| self.scroll.y, cell);
+}
+
+/// Use this function instead of `Window.readCell` to read the correct cell in scrolling context.
+pub fn readCell(self: *@This(), parent: vaxis.Window, col: usize, row: usize) ?vaxis.Cell {
+    const b = self.bounds(parent);
+    if (!b.inside(col, row)) return;
+    const win = parent.child(.{ .width = .{ .limit = b.width }, .height = .{ .limit = b.height } });
+    return win.readCell(col -| self.scroll.x, row -| self.scroll.y);
+}

--- a/src/widgets/TextView.zig
+++ b/src/widgets/TextView.zig
@@ -1,0 +1,186 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+const grapheme = @import("grapheme");
+const DisplayWidth = @import("DisplayWidth");
+const ScrollView = vaxis.widgets.ScrollView;
+
+pub const BufferWriter = struct {
+    pub const Error = error{OutOfMemory};
+    pub const Writer = std.io.GenericWriter(@This(), Error, write);
+
+    allocator: std.mem.Allocator,
+    buffer: *Buffer,
+    gd: *const grapheme.GraphemeData,
+    wd: *const DisplayWidth.DisplayWidthData,
+
+    pub fn write(self: @This(), bytes: []const u8) Error!usize {
+        try self.buffer.append(self.allocator, .{
+            .bytes = bytes,
+            .gd = self.gd,
+            .wd = self.wd,
+        });
+        return bytes.len;
+    }
+
+    pub fn writer(self: @This()) Writer {
+        return .{ .context = self };
+    }
+};
+
+pub const Buffer = struct {
+    const StyleList = std.ArrayListUnmanaged(vaxis.Style);
+    const StyleMap = std.HashMapUnmanaged(usize, usize, std.hash_map.AutoContext(usize), std.hash_map.default_max_load_percentage);
+
+    pub const Content = struct {
+        bytes: []const u8,
+        gd: *const grapheme.GraphemeData,
+        wd: *const DisplayWidth.DisplayWidthData,
+    };
+
+    pub const Style = struct {
+        begin: usize,
+        end: usize,
+        style: vaxis.Style,
+    };
+
+    grapheme: std.MultiArrayList(grapheme.Grapheme) = .{},
+    content: std.ArrayListUnmanaged(u8) = .{},
+    style_list: StyleList = .{},
+    style_map: StyleMap = .{},
+    rows: usize = 0,
+    cols: usize = 0,
+
+    pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
+        self.style_map.deinit(allocator);
+        self.style_list.deinit(allocator);
+        self.grapheme.deinit(allocator);
+        self.content.deinit(allocator);
+        self.* = undefined;
+    }
+
+    /// Clears all buffer data.
+    pub fn clear(self: *@This(), allocator: std.mem.Allocator) void {
+        self.deinit(allocator);
+        self.* = .{};
+    }
+
+    /// Replaces contents of the buffer, all previous buffer data is lost.
+    pub fn update(self: *@This(), allocator: std.mem.Allocator, content: Content) !void {
+        self.clear(allocator);
+        errdefer self.clear(allocator);
+        try self.append(allocator, content);
+    }
+
+    /// Appends content to the buffer.
+    pub fn append(self: *@This(), allocator: std.mem.Allocator, content: Content) !void {
+        var cols: usize = 0;
+        var iter = grapheme.Iterator.init(content.bytes, content.gd);
+        const dw: DisplayWidth = .{ .data = content.wd };
+        while (iter.next()) |g| {
+            try self.grapheme.append(allocator, .{
+                .len = g.len,
+                .offset = @as(u32, @intCast(self.content.items.len)) + g.offset,
+            });
+            const cluster = g.bytes(content.bytes);
+            if (std.mem.eql(u8, cluster, "\n")) {
+                self.cols = @max(self.cols, cols);
+                cols = 0;
+                continue;
+            }
+            cols +|= dw.strWidth(cluster);
+        }
+        try self.content.appendSlice(allocator, content.bytes);
+        self.cols = @max(self.cols, cols);
+        self.rows +|= std.mem.count(u8, content.bytes, "\n");
+    }
+
+    /// Clears all styling data.
+    pub fn clearStyle(self: *@This(), allocator: std.mem.Allocator) void {
+        self.style_list.deinit(allocator);
+        self.style_map.deinit(allocator);
+    }
+
+    /// Update style for range of the buffer contents.
+    pub fn updateStyle(self: *@This(), allocator: std.mem.Allocator, style: Style) !void {
+        const style_index = blk: {
+            for (self.style_list.items, 0..) |s, i| {
+                if (std.meta.eql(s, style.style)) {
+                    break :blk i;
+                }
+            }
+            try self.style_list.append(allocator, style.style);
+            break :blk self.style_list.items.len - 1;
+        };
+        for (style.begin..style.end) |i| {
+            try self.style_map.put(allocator, i, style_index);
+        }
+    }
+
+    pub fn writer(
+        self: *@This(),
+        allocator: std.mem.Allocator,
+        gd: *const grapheme.GraphemeData,
+        wd: *const DisplayWidth.DisplayWidthData,
+    ) BufferWriter.Writer {
+        return .{
+            .context = .{
+                .allocator = allocator,
+                .buffer = self,
+                .gd = gd,
+                .wd = wd,
+            },
+        };
+    }
+};
+
+scroll_view: ScrollView = .{},
+
+pub fn input(self: *@This(), key: vaxis.Key) void {
+    self.scroll_view.input(key);
+}
+
+pub fn draw(self: *@This(), win: vaxis.Window, buffer: Buffer) void {
+    self.scroll_view.draw(win, .{ .cols = buffer.cols, .rows = buffer.rows });
+    const Pos = struct { x: usize = 0, y: usize = 0 };
+    var pos: Pos = .{};
+    var byte_index: usize = 0;
+    const bounds = self.scroll_view.bounds(win);
+    for (buffer.grapheme.items(.len), buffer.grapheme.items(.offset), 0..) |g_len, g_offset, index| {
+        if (bounds.above(pos.y)) {
+            break;
+        }
+
+        const cluster = buffer.content.items[g_offset..][0..g_len];
+        defer byte_index += cluster.len;
+
+        if (std.mem.eql(u8, cluster, "\n")) {
+            if (index == buffer.grapheme.len - 1) {
+                break;
+            }
+            pos.y +|= 1;
+            pos.x = 0;
+            continue;
+        } else if (bounds.below(pos.y)) {
+            continue;
+        }
+
+        const width = win.gwidth(cluster);
+        defer pos.x +|= width;
+
+        if (!bounds.colInside(pos.x)) {
+            continue;
+        }
+
+        const style: vaxis.Style = blk: {
+            if (buffer.style_map.get(byte_index)) |style_index| {
+                break :blk buffer.style_list.items[style_index];
+            }
+            break :blk .{};
+        };
+
+        self.scroll_view.writeCell(win, pos.x, pos.y, .{
+            .char = .{ .grapheme = cluster, .width = width },
+            .style = style,
+        });
+    }
+}


### PR DESCRIPTION
![2024-06-01-002648_hyprshot](https://github.com/rockorager/libvaxis/assets/480330/1fd02e97-6518-4a13-a378-1cd3f506c384)

Scrolling is a very common need in CLI applications. The ScrollView widget allows you to implement a scrollable content trivially. Provided is also a TextView for showing text content which is also a common task. It is not covered in this PR, but it would be nice if TextView could wrap the rendered text in future.

CodeView is something I had already laying around. It could be useful for showing more code like content and provide as a good starting point for writing your own editor widget.