### PR TITLE
TextView: fix cols when appending to a buffer

### DIFF
--- a/src/widgets/TextView.zig
+++ b/src/widgets/TextView.zig
@@ -43,6 +43,8 @@ pub const Buffer = struct {
         style: vaxis.Style,
     };
 
+    pub const Error = error{OutOfMemory};
+
     grapheme: std.MultiArrayList(grapheme.Grapheme) = .{},
     content: std.ArrayListUnmanaged(u8) = .{},
     style_list: StyleList = .{},
@@ -67,14 +69,14 @@ pub const Buffer = struct {
     }
 
     /// Replaces contents of the buffer, all previous buffer data is lost.
-    pub fn update(self: *@This(), allocator: std.mem.Allocator, content: Content) !void {
+    pub fn update(self: *@This(), allocator: std.mem.Allocator, content: Content) Error!void {
         self.clear(allocator);
         errdefer self.clear(allocator);
         try self.append(allocator, content);
     }
 
     /// Appends content to the buffer.
-    pub fn append(self: *@This(), allocator: std.mem.Allocator, content: Content) !void {
+    pub fn append(self: *@This(), allocator: std.mem.Allocator, content: Content) Error!void {
         var cols: usize = self.last_cols;
         var iter = grapheme.Iterator.init(content.bytes, content.gd);
         const dw: DisplayWidth = .{ .data = content.wd };
@@ -104,7 +106,7 @@ pub const Buffer = struct {
     }
 
     /// Update style for range of the buffer contents.
-    pub fn updateStyle(self: *@This(), allocator: std.mem.Allocator, style: Style) !void {
+    pub fn updateStyle(self: *@This(), allocator: std.mem.Allocator, style: Style) Error!void {
         const style_index = blk: {
             for (self.style_list.items, 0..) |s, i| {
                 if (std.meta.eql(s, style.style)) {

--- a/src/widgets/TextView.zig
+++ b/src/widgets/TextView.zig
@@ -49,6 +49,8 @@ pub const Buffer = struct {
     style_map: StyleMap = .{},
     rows: usize = 0,
     cols: usize = 0,
+    // used when appending to a buffer
+    last_cols: usize = 0,
 
     pub fn deinit(self: *@This(), allocator: std.mem.Allocator) void {
         self.style_map.deinit(allocator);
@@ -73,7 +75,7 @@ pub const Buffer = struct {
 
     /// Appends content to the buffer.
     pub fn append(self: *@This(), allocator: std.mem.Allocator, content: Content) !void {
-        var cols: usize = 0;
+        var cols: usize = self.last_cols;
         var iter = grapheme.Iterator.init(content.bytes, content.gd);
         const dw: DisplayWidth = .{ .data = content.wd };
         while (iter.next()) |g| {
@@ -90,6 +92,7 @@ pub const Buffer = struct {
             cols +|= dw.strWidth(cluster);
         }
         try self.content.appendSlice(allocator, content.bytes);
+        self.last_cols = cols;
         self.cols = @max(self.cols, cols);
         self.rows +|= std.mem.count(u8, content.bytes, "\n");
     }


### PR DESCRIPTION
If appending to a buffer through writer for example, the cols may not be correct if the writes don't end up in a newline (\n). Fix this by keeping track of the cols of previous append.