### PR TITLE
fix: update to zig 0.13, broken test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.13.0
       - run: zig build test
   check-fmt:
     runs-on: ubuntu-latest
@@ -23,5 +23,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: goto-bus-stop/setup-zig@v2
         with:
-          version: 0.12.0
+          version: 0.13.0
       - run: zig fmt --check .

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .minimum_zig_version = "0.12.0",
     .dependencies = .{
         .zigimg = .{
-            .url = "git+https://github.com/zigimg/zigimg#637974e2d31dcdbc33f1e9cc8ffb2e46abd2e215",
-            .hash = "122012026c3a65ff1d4acba3b3fe80785f7cee9c6b4cdaff7ed0fbf23b0a6c803989",
+            .url = "git+https://github.com/zigimg/zigimg#3a667bdb3d7f0955a5a51c8468eac83210c1439e",
+            .hash = "1220dd654ef941fc76fd96f9ec6adadf83f69b9887a0d3f4ee5ac0a1a3e11be35cf5",
             .lazy = true,
         },
         .gap_buffer = .{
@@ -14,17 +14,17 @@
             .lazy = true,
         },
         .znvim = .{
-            .url = "git+https://github.com/jinzhongjia/znvim#7927b8042872d5fa5f30862302bea1290d372d4f",
-            .hash = "12202372c2043a9ac557144d327c09638ccd8d615bba459ba17d1a7a4197a213d939",
+            .url = "git+https://github.com/jinzhongjia/znvim#515fb2784f7b0db2ea7a0021aada8d4aa89a08fe",
+            .hash = "1220ca0a762fdf3172623e3f15890e396c975657d8ec57d907896f74ef94a37b73f2",
             .lazy = true,
         },
         .zg = .{
-            .url = "git+https://codeberg.org/dude_the_builder/zg#16735685fcc3410de361ba3411788ad1fb4fe188",
-            .hash = "1220fe9ac5cdb41833d327a78745614e67d472469f8666567bd8cf9f5847a52b1c51",
+            .url = "git+https://codeberg.org/dude_the_builder/zg#6d2ba3ff8f3cb7c86cef2b2176fb5b4a72c104dc",
+            .hash = "1220da2679c872f73b60b8071d96b9b0e7790ac1a1597e02bf91807d6089f3c89005",
         },
         .libxev = .{
-            .url = "git+https://github.com/mitchellh/libxev#b3f9918776b8700b337b7ebe769060328fe246b0",
-            .hash = "122044caf67c7833c7110dc93531031899e459a6818ed125a0bcfdb0b5243bd7700b",
+            .url = "git+https://github.com/mitchellh/libxev#f6a672a78436d8efee1aa847a43a900ad773618b",
+            .hash = "12207b7a5b538ffb7fb18f954ae17d2f8490b6e3778a9e30564ad82c58ee8da52361",
             .lazy = true,
         },
     },

--- a/src/Key.zig
+++ b/src/Key.zig
@@ -265,7 +265,7 @@ pub const iso_level_5_shift: u21 = 57454;
 
 pub const name_map = blk: {
     @setEvalBranchQuota(2000);
-    break :blk std.ComptimeStringMap(u21, .{
+    break :blk std.StaticStringMap(u21).initComptime(.{
         // common names
         .{ "plus", '+' },
         .{ "minus", '-' },

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -540,8 +540,8 @@ inline fn parseCsi(input: []const u8, text_buf: []u8) Result {
         'y' => {
             // DECRPM (CSI ? Ps ; Pm $ y)
             const delim_idx = std.mem.indexOfScalarPos(u8, input, 2, ';') orelse return null_event;
-            const ps = std.fmt.parseUnsigned(u16, input[3..delim_idx], 10) catch return null_event;
-            const pm = std.fmt.parseUnsigned(u8, input[delim_idx + 1 .. sequence.len - 2], 10) catch return null_event;
+            const ps = std.fmt.parseUnsigned(u16, input[2..delim_idx], 10) catch return null_event;
+            const pm = std.fmt.parseUnsigned(u8, input[delim_idx + 1 .. sequence.len - 1], 10) catch return null_event;
             switch (ps) {
                 // Mouse Pixel reporting
                 1016 => switch (pm) {


### PR DESCRIPTION
this PR updates dependencies and `Key.zig` for compilation with zig 0.13.0. along the way i noticed that the test for `.cap_sgr_pixels` was failing, because the parsing logic was consuming the relevant character; the test now passes.