### PR TITLE
build: export some symbols for thespian.Loop

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -23,6 +23,9 @@ pub const Window = @import("Window.zig");
 pub const widgets = @import("widgets.zig");
 pub const gwidth = @import("gwidth.zig");
 pub const ctlseqs = @import("ctlseqs.zig");
+pub const GraphemeCache = @import("GraphemeCache.zig");
+pub const grapheme = @import("grapheme");
+pub const Event = @import("event.zig").Event;
 
 /// The target TTY implementation
 pub const Tty = switch (builtin.os.tag) {


### PR DESCRIPTION
Writing a custom Loop requires a few symbols that are not yet exported.