### PR TITLE
Changed the default value of the nvim option to correspond to it's description

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const include_libxev = b.option(bool, "libxev", "Enable support for libxev library (default: true)") orelse true;
     const include_images = b.option(bool, "images", "Enable support for images (default: true)") orelse true;
-    const include_nvim = b.option(bool, "nvim", "Enable support for the neovim widget (default: false)") orelse true;
+    const include_nvim = b.option(bool, "nvim", "Enable support for the neovim widget (default: false)") orelse false;
     const include_text_input = b.option(bool, "text_input", "Enable support for the TextInput widget (default: true)") orelse true;
 
     const options = b.addOptions();


### PR DESCRIPTION
`build.zig` file contains options to build the project.

One of these options is include_nvim, on line 5, as following:

```
[...]
const include_nvim = b.option(bool, "nvim", "Enable support for the neovim widget (default: false)") orelse true;
[...]
```

I've changed the default value (`orelse true`) to match the default description (`default: false`), resulting in the following:

```
[...]
const include_nvim = b.option(bool, "nvim", "Enable support for the neovim widget (default: false)") orelse false; 
[...]
```

Nice project BTW.