### PR TITLE
fix: add ThreadPool for key events on macOS

### DIFF
--- a/examples/xev.zig
+++ b/examples/xev.zig
@@ -60,7 +60,10 @@ pub fn main() !void {
     var vx = try vaxis.init(alloc, .{});
     defer vx.deinit(alloc, tty.anyWriter());
 
-    var loop = try xev.Loop.init(.{});
+    var pool = xev.ThreadPool.init(.{});
+    var loop = try xev.Loop.init(.{
+        .thread_pool = &pool,
+    });
     defer loop.deinit();
 
     var app: App = .{


### PR DESCRIPTION
key events (and in fact all reads) on macOS via libxev require a thread pool. this PR adds a thread pool to the `xev` example.