### PR TITLE
fix: don't call the callback synchronously on watcher init

### DIFF
--- a/src/xev.zig
+++ b/src/xev.zig
@@ -99,8 +99,6 @@ pub fn TtyWatcher(comptime Userdata: type) type {
                 .callback = Self.signalCallback,
             };
             try Tty.notifyWinsize(handler);
-            const winsize = try Tty.getWinsize(self.tty.fd);
-            _ = self.callback(self.ud, loop, self, .{ .winsize = winsize });
         }
 
         fn signalCallback(ptr: *anyopaque) void {


### PR DESCRIPTION
This makes `xev.TtyWatcher` behave according to my expectations: namely that the callback will only fire after the function which registers it has returned.