### PR TITLE
fix: use u64 for render_dur so that *Vaxis becomes align(8)

### DIFF
--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -68,7 +68,7 @@ unicode: Unicode,
 
 // statistics
 renders: usize = 0,
-render_dur: i128 = 0,
+render_dur: u64 = 0,
 render_timer: std.time.Timer,
 
 sgr: enum {


### PR DESCRIPTION
on macOS, `@alignOf(std.c.max_align_t)` is 8, while `@alignOf(i128)` is 16. since we moved to using `std.time.Timer`, render duration should always be an unsigned quantity.

this change is motivated by my seamstress project, which wants to use a Vaxis struct (well, something with a Vaxis struct as a field) as a Lua userdata. it turns out that Lua won't allocate at an alignment greater than `@alignOf(std.c.max_align_t)` even if you ask it to.