### PR TITLE
aio: update aio, add LoopWithModules

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -23,8 +23,8 @@
             .lazy = true,
         },
         .aio = .{
-            .url = "git+https://github.com/Cloudef/zig-aio#407bb416136b61087cec2c561fa4b4103a44c5b1",
-            .hash = "12202405ca6dd40f314dba6472983fcbb388118ab7446d75065b1efb982d03f515d2",
+            .url = "git+https://github.com/Cloudef/zig-aio#b5a407344379508466c5dcbe4c74438a6166e2ca",
+            .hash = "1220a55aedabdd10578d0c514719ea39ae1bc6d7ed990f508dc100db7f0ccf391437",
             .lazy = true,
         },
     },

--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -164,6 +164,7 @@ pub fn Loop(comptime T: type) type {
     };
 }
 
+// Use return on the self.postEvent's so it can either return error union or void
 pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Event: type, event: anytype, paste_allocator: ?std.mem.Allocator) !void {
     switch (builtin.os.tag) {
         .windows => {
@@ -298,7 +299,7 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                 .winsize => |winsize| {
                     vx.state.in_band_resize = true;
                     if (@hasField(Event, "winsize")) {
-                        self.postEvent(.{ .winsize = winsize });
+                        return self.postEvent(.{ .winsize = winsize });
                     }
                 },
             }

--- a/src/aio.zig
+++ b/src/aio.zig
@@ -1,16 +1,25 @@
+const build_options = @import("build_options");
 const builtin = @import("builtin");
 const std = @import("std");
-const aio = @import("aio");
-const coro = @import("coro");
 const vaxis = @import("main.zig");
 const handleEventGeneric = @import("Loop.zig").handleEventGeneric;
 const log = std.log.scoped(.vaxis_aio);
 
 const Yield = enum { no_state, took_event };
 
+pub fn Loop(T: type) type {
+    if (!build_options.aio) {
+        @compileError(
+            \\build_options.aio is not enabled.
+            \\Use `LoopWithModules` instead to provide `aio` and `coro` modules from outside vaxis.
+        );
+    }
+    return LoopWithModules(T, @import("aio"), @import("coro"));
+}
+
 /// zig-aio based event loop
 /// <https://github.com/Cloudef/zig-aio>
-pub fn Loop(comptime T: type) type {
+pub fn LoopWithModules(T: type, aio: type, coro: type) type {
     return struct {
         const Event = T;
 


### PR DESCRIPTION
AFAIK zig lacks a way of overriding module dependencies of dependencies. LoopWithModules lets you use aio backend with vaxis using aio and coro modules that are not included by vaxis, when this function is used `include_aio` is not neccessary.