### PR TITLE
Remove incorrect pointer capture

### DIFF
--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -184,7 +184,7 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                         return self.postEvent(.{ .key_press = mut_key });
                     }
                 },
-                .key_release => |*key| {
+                .key_release => |key| {
                     if (@hasField(Event, "key_release")) {
                         // HACK: yuck. there has to be a better way
                         var mut_key = key;


### PR DESCRIPTION
Because the event is passed as a copy, the reference is `*const`, which caused the `mut_key.text = cache.put(text)` line to fail, since it was trying to modify the field of an immutable reference.