### PR TITLE
fix memleak with transmitted image example

### DIFF
--- a/examples/image.zig
+++ b/examples/image.zig
@@ -34,6 +34,8 @@ pub fn main() !void {
     try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
 
     var img1 = try vaxis.zigimg.Image.fromFilePath(alloc, "examples/zig.png");
+    defer img1.deinit();
+
     const imgs = [_]vaxis.Image{
         try vx.transmitImage(alloc, tty.anyWriter(), &img1, .rgba),
         // var img1 = try vaxis.zigimg.Image.fromFilePath(alloc, "examples/zig.png");


### PR DESCRIPTION
The transmitted zig image is copied, instead of having its ownership transferred. So we need to add deinit to the image.

Closes #66 