### PR TITLE
vaxis: attempt to reset cursor shape

### DIFF
--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -114,6 +114,11 @@ pub fn deinit(self: *Vaxis, alloc: ?std.mem.Allocator, tty: AnyWriter) void {
 
     // always show the cursor on exit
     tty.writeAll(ctlseqs.show_cursor) catch {};
+    if (self.screen.cursor_shape != .default) {
+        // In many terminals, `.default` will set to the configured cursor shape. Others, it will
+        // change to a blinking block.
+        tty.print(ctlseqs.cursor_shape, .{@intFromEnum(Cell.CursorShape.default)}) catch {};
+    }
     if (alloc) |a| {
         self.screen.deinit(a);
         self.screen_last.deinit(a);


### PR DESCRIPTION
Attempt to reset the cursor shape on exit, if the shape has been
changed. This won't work on every terminal, however some implement
`\x1b[0 q` as setting the shape to the "default" value, others implement
it as a blinking block.

Fixes: #77
