### PR TITLE
Adding saturating subtraction for width in Window.child

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -170,11 +170,11 @@ pub fn child(self: Window, opts: ChildOptions) Window {
     if (loc.top and loc.left)
         result.writeCell(0, 0, .{ .char = top_left, .style = style });
     if (loc.top and loc.right)
-        result.writeCell(w - 1, 0, .{ .char = top_right, .style = style });
+        result.writeCell(w -| 1, 0, .{ .char = top_right, .style = style });
     if (loc.bottom and loc.left)
         result.writeCell(0, h -| 1, .{ .char = bottom_left, .style = style });
     if (loc.bottom and loc.right)
-        result.writeCell(w - 1, h -| 1, .{ .char = bottom_right, .style = style });
+        result.writeCell(w -| 1, h -| 1, .{ .char = bottom_right, .style = style });
 
     const x_off: usize = if (loc.left) 1 else 0;
     const y_off: usize = if (loc.top) 1 else 0;


### PR DESCRIPTION
I was seeing the following error:

> thread 29177 panic: integer overflow
> /home/Southporter/.cache/zig/p/1220fef553676a4c90035db27c13ad609d5823198a94cc971e95ab9c680e3dcd2df0/src/Window.zig:177:28: 0x10b5e42 in child (snail)
>         result.writeCell(w - 1, h -| 1, .{ .char = bottom_right, .style = style });

It looks like the height has saturating subtraction, but not the width offset.

I started running into this when I switched to the xev based loop, didn't really see it for the default vaxis loop.