### PR TITLE
window: make print infallible

### DIFF
--- a/examples/cli.zig
+++ b/examples/cli.zig
@@ -92,7 +92,7 @@ pub fn main() !void {
                     .text = opt,
                     .style = if (j == i) .{ .reverse = true } else .{},
                 }};
-                _ = try win.print(&seg, .{ .row_offset = j + 1 });
+                _ = win.print(&seg, .{ .row_offset = j + 1 });
             }
         }
         try vx.render(tty.anyWriter());

--- a/examples/table.zig
+++ b/examples/table.zig
@@ -239,7 +239,7 @@ pub fn main() !void {
                             .style = .{ .bg = ctx.bg },
                         },
                     };
-                    _ = try see_win.print(content_segs, .{});
+                    _ = see_win.print(content_segs, .{});
                     return see_win.height;
                 }
             }.see;
@@ -269,7 +269,7 @@ pub fn main() !void {
             44,
             top_bar.height - (top_bar.height / 3),
         );
-        _ = try logo_bar.print(title_segs[0..], .{ .wrap = .word });
+        _ = logo_bar.print(title_segs[0..], .{ .wrap = .word });
 
         // - Middle
         const middle_bar = win.child(.{

--- a/examples/vaxis.zig
+++ b/examples/vaxis.zig
@@ -78,7 +78,7 @@ pub fn main() !void {
             .style = style,
         };
         const center = vaxis.widgets.alignment.center(win, 28, 4);
-        _ = try center.printSegment(segment, .{ .wrap = .grapheme });
+        _ = center.printSegment(segment, .{ .wrap = .grapheme });
         try vx.render(tty.anyWriter());
         std.time.sleep(16 * std.time.ns_per_ms);
         switch (dir) {

--- a/examples/view.zig
+++ b/examples/view.zig
@@ -74,7 +74,7 @@ pub fn main() !void {
     //h = lg_map_view.screen.height;
     var lg_map_buf: [lg_map_width * lg_map_height]u8 = undefined;
     _ = mem.replace(u8, lg_world_map, "\n", "", lg_map_buf[0..]);
-    _ = try lg_map_view.printSegment(.{ .text = lg_map_buf[0..] }, .{ .wrap = .grapheme });
+    _ = lg_map_view.printSegment(.{ .text = lg_map_buf[0..] }, .{ .wrap = .grapheme });
     // - Small Map
     var sm_map_view = try View.init(alloc, &vx.unicode, .{ .width = sm_map_width, .height = sm_map_height });
     defer sm_map_view.deinit();
@@ -82,7 +82,7 @@ pub fn main() !void {
     h = sm_map_view.screen.height;
     var sm_map_buf: [sm_map_width * sm_map_height]u8 = undefined;
     _ = mem.replace(u8, sm_world_map, "\n", "", sm_map_buf[0..]);
-    _ = try sm_map_view.printSegment(.{ .text = sm_map_buf[0..] }, .{ .wrap = .grapheme });
+    _ = sm_map_view.printSegment(.{ .text = sm_map_buf[0..] }, .{ .wrap = .grapheme });
     // - Active Map
     var map_view = lg_map_view;
 
@@ -137,7 +137,7 @@ pub fn main() !void {
         const controls_win = win.child(.{
             .height = .{ .limit = 1 },
         });
-        _ = try controls_win.print(
+        _ = controls_win.print(
             if (win.width >= 112) &.{
                 .{ .text = "Controls:", .style = .{ .bold = true, .ul_style = .single } },
                 .{ .text = " Exit: ctrl + c | Scroll: dpad | Quick Scroll: ctrl + dpad | Goto Side: shift + dpad | Zoom: z | Mini: m" },
@@ -173,7 +173,7 @@ pub fn main() !void {
             .y_off = y,
         });
         if (use_mini_view) {
-            _ = try win.printSegment(
+            _ = win.printSegment(
                 .{ .text = "This is a mini portion of the View." },
                 .{ .row_offset = 16, .col_offset = 5, .wrap = .word },
             );

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -280,7 +280,7 @@ pub const PrintResult = struct {
 
 /// prints segments to the window. returns true if the text overflowed with the
 /// given wrap strategy and size.
-pub fn print(self: Window, segments: []const Segment, opts: PrintOptions) !PrintResult {
+pub fn print(self: Window, segments: []const Segment, opts: PrintOptions) PrintResult {
     var row = opts.row_offset;
     switch (opts.wrap) {
         .grapheme => {
@@ -437,7 +437,7 @@ pub fn print(self: Window, segments: []const Segment, opts: PrintOptions) !Print
 }
 
 /// print a single segment. This is just a shortcut for print(&.{segment}, opts)
-pub fn printSegment(self: Window, segment: Segment, opts: PrintOptions) !PrintResult {
+pub fn printSegment(self: Window, segment: Segment, opts: PrintOptions) PrintResult {
     return self.print(&.{segment}, opts);
 }
 
@@ -547,7 +547,7 @@ test "print: grapheme" {
         var segments = [_]Segment{
             .{ .text = "a" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(1, result.col);
         try std.testing.expectEqual(0, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -556,7 +556,7 @@ test "print: grapheme" {
         var segments = [_]Segment{
             .{ .text = "abcd" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(0, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -565,7 +565,7 @@ test "print: grapheme" {
         var segments = [_]Segment{
             .{ .text = "abcde" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(1, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -574,7 +574,7 @@ test "print: grapheme" {
         var segments = [_]Segment{
             .{ .text = "abcdefgh" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(0, result.col);
         try std.testing.expectEqual(2, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -583,7 +583,7 @@ test "print: grapheme" {
         var segments = [_]Segment{
             .{ .text = "abcdefghi" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(0, result.col);
         try std.testing.expectEqual(2, result.row);
         try std.testing.expectEqual(true, result.overflow);
@@ -614,7 +614,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "a" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(1, result.col);
         try std.testing.expectEqual(0, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -623,7 +623,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = " " },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(1, result.col);
         try std.testing.expectEqual(0, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -632,7 +632,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = " a" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(2, result.col);
         try std.testing.expectEqual(0, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -641,7 +641,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "a b" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(3, result.col);
         try std.testing.expectEqual(0, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -650,7 +650,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "a b c" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(1, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -659,7 +659,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "hello" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(1, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -668,7 +668,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "hi tim" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(3, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -677,7 +677,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "hello tim" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(0, result.col);
         try std.testing.expectEqual(2, result.row);
         try std.testing.expectEqual(true, result.overflow);
@@ -686,7 +686,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "hello ti" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(0, result.col);
         try std.testing.expectEqual(2, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -696,7 +696,7 @@ test "print: word" {
             .{ .text = "h" },
             .{ .text = "e" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(2, result.col);
         try std.testing.expectEqual(0, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -709,7 +709,7 @@ test "print: word" {
             .{ .text = "l" },
             .{ .text = "o" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(1, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -718,7 +718,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "he\n" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(0, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -727,7 +727,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "he\n\n" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(0, result.col);
         try std.testing.expectEqual(2, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -736,7 +736,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "not now" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(3, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -745,7 +745,7 @@ test "print: word" {
         var segments = [_]Segment{
             .{ .text = "note now" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(3, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -755,7 +755,7 @@ test "print: word" {
             .{ .text = "note" },
             .{ .text = " now" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(3, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);
@@ -765,7 +765,7 @@ test "print: word" {
             .{ .text = "note " },
             .{ .text = "now" },
         };
-        const result = try win.print(&segments, opts);
+        const result = win.print(&segments, opts);
         try std.testing.expectEqual(3, result.col);
         try std.testing.expectEqual(1, result.row);
         try std.testing.expectEqual(false, result.overflow);

--- a/src/widgets/Table.zig
+++ b/src/widgets/Table.zig
@@ -255,7 +255,7 @@ pub fn drawTable(
                 .ul_style = if (idx == table_ctx.col) .single else .dotted,
             },
         }};
-        _ = try hdr.print(seg[0..], .{ .wrap = .word });
+        _ = hdr.print(seg[0..], .{ .wrap = .word });
     }
 
     // Rows
@@ -378,7 +378,7 @@ pub fn drawTable(
                     .text = if (item_txt.len > col_width and alloc != null) try fmt.allocPrint(alloc.?, "{s}...", .{item_txt[0..(col_width -| 4)]}) else item_txt,
                     .style = .{ .fg = row_fg, .bg = row_bg },
                 }};
-                _ = try item_align_win.print(seg[0..], .{ .wrap = .word, .col_offset = table_ctx.cell_x_off });
+                _ = item_align_win.print(seg[0..], .{ .wrap = .word, .col_offset = table_ctx.cell_x_off });
             }
         }
     }

--- a/src/widgets/View.zig
+++ b/src/widgets/View.zig
@@ -149,11 +149,11 @@ pub fn fill(self: View, cell: Cell) void {
 
 /// Prints segments to the View. Returns true if the text overflowed with the
 /// given wrap strategy and size.
-pub fn print(self: *View, segments: []const Cell.Segment, opts: Window.PrintOptions) !Window.PrintResult {
+pub fn print(self: *View, segments: []const Cell.Segment, opts: Window.PrintOptions) Window.PrintResult {
     return self.window().print(segments, opts);
 }
 
 /// Print a single segment. This is just a shortcut for print(&.{segment}, opts)
-pub fn printSegment(self: *View, segment: Cell.Segment, opts: Window.PrintOptions) !Window.PrintResult {
+pub fn printSegment(self: *View, segment: Cell.Segment, opts: Window.PrintOptions) Window.PrintResult {
     return self.print(&.{segment}, opts);
 }


### PR DESCRIPTION
Print and PrintSegment are now infallible due to gwidth also being
infallible. The previous error was only error.OutOfMemory if a temporary
buffer was too small to encode text in gwidth. This has been removed in
favor or a for loop
