### PR TITLE
Add application framework

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,8 +28,8 @@ pub fn build(b: *std.Build) void {
 
     // Examples
     const Example = enum {
-        aio,
         cli,
+        fuzzy,
         image,
         main,
         nvim,
@@ -38,7 +38,6 @@ pub fn build(b: *std.Build) void {
         vaxis,
         view,
         vt,
-        xev,
     };
     const example_option = b.option(Example, "example", "Example to run (default: text_input)") orelse .text_input;
     const example_step = b.step("example", "Run example");

--- a/examples/fuzzy.zig
+++ b/examples/fuzzy.zig
@@ -1,0 +1,235 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+
+const Model = struct {
+    list: std.ArrayList(vxfw.Text),
+    filtered: std.ArrayList(vxfw.RichText),
+    list_view: vxfw.ListView,
+    text_field: vxfw.TextField,
+    result: []const u8,
+    unicode_data: *const vaxis.Unicode,
+
+    /// Used for filtered RichText Spans
+    arena: std.heap.ArenaAllocator,
+
+    pub fn widget(self: *Model) vxfw.Widget {
+        return .{
+            .userdata = self,
+            .eventHandler = Model.typeErasedEventHandler,
+            .drawFn = Model.typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        switch (event) {
+            .init => {
+                // Initialize the filtered list
+                const allocator = self.arena.allocator();
+                for (self.list.items) |line| {
+                    var spans = std.ArrayList(vxfw.RichText.TextSpan).init(allocator);
+                    const span: vxfw.RichText.TextSpan = .{ .text = line.text };
+                    try spans.append(span);
+                    try self.filtered.append(.{ .text = spans.items });
+                }
+
+                return ctx.requestFocus(self.text_field.widget());
+            },
+            .key_press => |key| {
+                if (key.matches('c', .{ .ctrl = true })) {
+                    ctx.quit = true;
+                    return;
+                }
+                return self.list_view.handleEvent(ctx, event);
+            },
+            .focus_in => {
+                return ctx.requestFocus(self.text_field.widget());
+            },
+            else => {},
+        }
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        const max = ctx.max.size();
+
+        var list_view: vxfw.SubSurface = .{
+            .origin = .{ .row = 2, .col = 0 },
+            .surface = try self.list_view.draw(ctx.withConstraints(
+                ctx.min,
+                .{ .width = max.width, .height = max.height - 3 },
+            )),
+        };
+        list_view.surface.focusable = false;
+
+        const text_field: vxfw.SubSurface = .{
+            .origin = .{ .row = 0, .col = 2 },
+            .surface = try self.text_field.draw(ctx.withConstraints(
+                ctx.min,
+                .{ .width = max.width, .height = 1 },
+            )),
+        };
+
+        const prompt: vxfw.Text = .{ .text = "", .style = .{ .fg = .{ .index = 4 } } };
+
+        const prompt_surface: vxfw.SubSurface = .{
+            .origin = .{ .row = 0, .col = 0 },
+            .surface = try prompt.draw(ctx.withConstraints(ctx.min, .{ .width = 2, .height = 1 })),
+        };
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 3);
+        children[0] = list_view;
+        children[1] = text_field;
+        children[2] = prompt_surface;
+
+        return .{
+            .size = max,
+            .widget = self.widget(),
+            .focusable = true,
+            .buffer = &.{},
+            .children = children,
+        };
+    }
+
+    fn widgetBuilder(ptr: *const anyopaque, idx: usize, _: usize) ?vxfw.Widget {
+        const self: *const Model = @ptrCast(@alignCast(ptr));
+        if (idx >= self.filtered.items.len) return null;
+
+        return self.filtered.items[idx].widget();
+    }
+
+    fn onChange(maybe_ptr: ?*anyopaque, _: *vxfw.EventContext, str: []const u8) anyerror!void {
+        const ptr = maybe_ptr orelse return;
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        self.filtered.clearAndFree();
+        _ = self.arena.reset(.free_all);
+        const allocator = self.arena.allocator();
+
+        const hasUpper = for (str) |b| {
+            if (std.ascii.isUpper(b)) break true;
+        } else false;
+
+        // Loop each line
+        // If our input is only lowercase, we convert the line to lowercase
+        // Iterate the input graphemes, looking for them _in order_ in the line
+        outer: for (self.list.items) |item| {
+            const tgt = if (hasUpper)
+                item.text
+            else
+                try toLower(allocator, item.text);
+
+            var spans = std.ArrayList(vxfw.RichText.TextSpan).init(allocator);
+            var i: usize = 0;
+            var iter = self.unicode_data.graphemeIterator(str);
+            while (iter.next()) |g| {
+                if (std.mem.indexOfPos(u8, tgt, i, g.bytes(str))) |idx| {
+                    const up_to_here: vxfw.RichText.TextSpan = .{ .text = item.text[i..idx] };
+                    const match: vxfw.RichText.TextSpan = .{
+                        .text = item.text[idx .. idx + g.len],
+                        .style = .{ .fg = .{ .index = 4 }, .reverse = true },
+                    };
+                    try spans.append(up_to_here);
+                    try spans.append(match);
+                    i = idx + g.len;
+                } else continue :outer;
+            }
+            const up_to_here: vxfw.RichText.TextSpan = .{ .text = item.text[i..] };
+            try spans.append(up_to_here);
+            try self.filtered.append(.{ .text = spans.items });
+        }
+        self.list_view.scroll.top = 0;
+        self.list_view.scroll.offset = 0;
+        self.list_view.cursor = 0;
+    }
+
+    fn onSubmit(maybe_ptr: ?*anyopaque, ctx: *vxfw.EventContext, _: []const u8) anyerror!void {
+        const ptr = maybe_ptr orelse return;
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        if (self.list_view.cursor < self.filtered.items.len) {
+            const selected = self.filtered.items[self.list_view.cursor];
+            const allocator = self.arena.allocator();
+            var result: std.ArrayListUnmanaged(u8) = .{};
+            for (selected.text) |span| {
+                try result.appendSlice(allocator, span.text);
+            }
+            self.result = result.items;
+        }
+        ctx.quit = true;
+    }
+};
+
+fn toLower(allocator: std.mem.Allocator, src: []const u8) std.mem.Allocator.Error![]const u8 {
+    const lower = try allocator.alloc(u8, src.len);
+    for (src, 0..) |b, i| {
+        lower[i] = std.ascii.toLower(b);
+    }
+    return lower;
+}
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const allocator = gpa.allocator();
+
+    var app = try vxfw.App.init(allocator);
+    errdefer app.deinit();
+
+    const model = try allocator.create(Model);
+    defer allocator.destroy(model);
+    model.* = .{
+        .list = std.ArrayList(vxfw.Text).init(allocator),
+        .filtered = std.ArrayList(vxfw.RichText).init(allocator),
+        .list_view = .{
+            .children = .{
+                .builder = .{
+                    .userdata = model,
+                    .buildFn = Model.widgetBuilder,
+                },
+            },
+        },
+        .text_field = .{
+            .buf = vxfw.TextField.Buffer.init(allocator),
+            .unicode = &app.vx.unicode,
+            .userdata = model,
+            .onChange = Model.onChange,
+            .onSubmit = Model.onSubmit,
+        },
+        .result = "",
+        .arena = std.heap.ArenaAllocator.init(allocator),
+        .unicode_data = &app.vx.unicode,
+    };
+    defer model.text_field.deinit();
+    defer model.list.deinit();
+    defer model.filtered.deinit();
+    defer model.arena.deinit();
+
+    // Run the command
+    var fd = std.process.Child.init(&.{"fd"}, allocator);
+    fd.stdout_behavior = .Pipe;
+    fd.stderr_behavior = .Pipe;
+    var stdout = std.ArrayList(u8).init(allocator);
+    var stderr = std.ArrayList(u8).init(allocator);
+    defer stdout.deinit();
+    defer stderr.deinit();
+    try fd.spawn();
+    try fd.collectOutput(&stdout, &stderr, 10_000_000);
+    _ = try fd.wait();
+
+    var iter = std.mem.splitScalar(u8, stdout.items, '\n');
+    while (iter.next()) |line| {
+        if (line.len == 0) continue;
+        try model.list.append(.{ .text = line });
+    }
+
+    try app.run(model.widget(), .{});
+    app.deinit();
+
+    if (model.result.len > 0) {
+        const writer = std.io.getStdOut().writer();
+        try writer.print("{s}\n", .{model.result});
+    } else {
+        std.process.exit(130);
+    }
+}

--- a/examples/split_view.zig
+++ b/examples/split_view.zig
@@ -1,0 +1,73 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+
+const Model = struct {
+    split: vxfw.SplitView,
+    lhs: vxfw.Text,
+    rhs: vxfw.Text,
+    children: [1]vxfw.SubSurface = undefined,
+
+    pub fn widget(self: *Model) vxfw.Widget {
+        return .{
+            .userdata = self,
+            .eventHandler = Model.typeErasedEventHandler,
+            .drawFn = Model.typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        switch (event) {
+            .init => {
+                self.split.lhs = self.lhs.widget();
+                self.split.rhs = self.rhs.widget();
+            },
+            .key_press => |key| {
+                if (key.matches('c', .{ .ctrl = true })) {
+                    ctx.quit = true;
+                    return;
+                }
+            },
+            else => {},
+        }
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        const surf = try self.split.widget().draw(ctx);
+        self.children[0] = .{
+            .surface = surf,
+            .origin = .{ .row = 0, .col = 0 },
+        };
+        return .{
+            .size = ctx.max.size(),
+            .widget = self.widget(),
+            .buffer = &.{},
+            .children = &self.children,
+        };
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const allocator = gpa.allocator();
+
+    var app = try vxfw.App.init(allocator);
+    defer app.deinit();
+
+    const model = try allocator.create(Model);
+    defer allocator.destroy(model);
+    model.* = .{
+        .lhs = .{ .text = "Left hand side" },
+        .rhs = .{ .text = "right hand side" },
+        .split = .{ .lhs = undefined, .rhs = undefined, .width = 10 },
+    };
+
+    model.split.lhs = model.lhs.widget();
+    model.split.rhs = model.rhs.widget();
+
+    try app.run(model.widget(), .{});
+}

--- a/src/Screen.zig
+++ b/src/Screen.zig
@@ -50,28 +50,18 @@ pub fn deinit(self: *Screen, alloc: std.mem.Allocator) void {
 
 /// writes a cell to a location. 0 indexed
 pub fn writeCell(self: *Screen, col: u16, row: u16, cell: Cell) void {
-    if (self.width <= col) {
-        // column out of bounds
+    if (col >= self.width or
+        row >= self.height)
         return;
-    }
-    if (self.height <= row) {
-        // height out of bounds
-        return;
-    }
     const i = (row * self.width) + col;
     assert(i < self.buf.len);
     self.buf[i] = cell;
 }
 
 pub fn readCell(self: *const Screen, col: u16, row: u16) ?Cell {
-    if (self.width <= col) {
-        // column out of bounds
+    if (col >= self.width or
+        row >= self.height)
         return null;
-    }
-    if (self.height <= row) {
-        // height out of bounds
-        return null;
-    }
     const i = (row * self.width) + col;
     assert(i < self.buf.len);
     return self.buf[i];

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,6 +30,8 @@ pub const grapheme = @import("grapheme");
 pub const Event = @import("event.zig").Event;
 pub const Unicode = @import("Unicode.zig");
 
+pub const vxfw = @import("vxfw/vxfw.zig");
+
 pub const Tty = tty.Tty;
 
 /// The size of the terminal screen

--- a/src/main.zig
+++ b/src/main.zig
@@ -73,16 +73,6 @@ pub const logo =
     \\ ▀▄▀  █   █ █   █ ▄█▄ ▀▄▄▄▀
 ;
 
-test {
-    _ = @import("gwidth.zig");
-    _ = @import("Cell.zig");
-    _ = @import("Key.zig");
-    _ = @import("Parser.zig");
-    _ = @import("Window.zig");
-
-    _ = @import("gwidth.zig");
-    _ = @import("queue.zig");
-    _ = @import("widgets/TextInput.zig");
-
-    _ = @import("Loop.zig");
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
 }

--- a/src/vxfw/App.zig
+++ b/src/vxfw/App.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const vaxis = @import("vaxis");
+const vaxis = @import("../main.zig");
 const vxfw = @import("vxfw.zig");
 
 const assert = std.debug.assert;

--- a/src/vxfw/App.zig
+++ b/src/vxfw/App.zig
@@ -63,7 +63,7 @@ pub fn run(self: *App, widget: vxfw.Widget, opts: Options) anyerror!void {
         if (!vx.state.in_band_resize) try loop.init();
     }
 
-    // HACK: Ghostty is reporting incorrect pixel screen size
+    // NOTE: We don't use pixel mouse anywhere
     vx.caps.sgr_pixels = false;
     try vx.setMouseMode(tty.anyWriter(), true);
 
@@ -402,6 +402,7 @@ const FocusHandler = struct {
     }
 
     fn deinit(self: *FocusHandler) void {
+        self.path_to_focused.deinit();
         self.arena.deinit();
     }
 

--- a/src/vxfw/App.zig
+++ b/src/vxfw/App.zig
@@ -196,11 +196,14 @@ fn checkTimers(self: *App, ctx: *vxfw.EventContext) anyerror!void {
 
     // timers are always sorted descending
     while (self.timers.popOrNull()) |tick| {
-        if (now_ms < tick.deadline_ms)
+        if (now_ms < tick.deadline_ms) {
+            // re-add the timer
+            try self.timers.append(tick);
             break;
+        }
         try tick.widget.handleEvent(ctx, .tick);
-        try self.handleCommand(&ctx.cmds);
     }
+    try self.handleCommand(&ctx.cmds);
 }
 
 const MouseHandler = struct {

--- a/src/vxfw/App.zig
+++ b/src/vxfw/App.zig
@@ -1,0 +1,491 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = @import("vxfw.zig");
+
+const assert = std.debug.assert;
+
+const Allocator = std.mem.Allocator;
+
+const EventLoop = vaxis.Loop(vxfw.Event);
+const Widget = vxfw.Widget;
+
+const App = @This();
+
+quit_key: vaxis.Key = .{ .codepoint = 'c', .mods = .{ .ctrl = true } },
+
+allocator: Allocator,
+tty: vaxis.Tty,
+vx: vaxis.Vaxis,
+timers: std.ArrayList(vxfw.Tick),
+wants_focus: ?vxfw.Widget,
+
+/// Runtime options
+pub const Options = struct {
+    /// Frames per second
+    framerate: u8 = 60,
+};
+
+/// Create an application. We require stable pointers to do the set up, so this will create an App
+/// object on the heap. Call destroy when the app is complete to reset terminal state and release
+/// resources
+pub fn init(allocator: Allocator) !App {
+    return .{
+        .allocator = allocator,
+        .tty = try vaxis.Tty.init(),
+        .vx = try vaxis.init(allocator, .{ .system_clipboard_allocator = allocator }),
+        .timers = std.ArrayList(vxfw.Tick).init(allocator),
+        .wants_focus = null,
+    };
+}
+
+pub fn deinit(self: *App) void {
+    self.timers.deinit();
+    self.vx.deinit(self.allocator, self.tty.anyWriter());
+    self.tty.deinit();
+}
+
+pub fn run(self: *App, widget: vxfw.Widget, opts: Options) anyerror!void {
+    const tty = &self.tty;
+    const vx = &self.vx;
+
+    var loop: EventLoop = .{ .tty = tty, .vaxis = vx };
+    try loop.start();
+    defer loop.stop();
+
+    // Send the init event
+    loop.postEvent(.init);
+
+    try vx.enterAltScreen(tty.anyWriter());
+    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+
+    {
+        // This part deserves a comment. loop.init installs a signal handler for the tty. We wait to
+        // init the loop until we know if we need this handler. We don't need it if the terminal
+        // supports in-band-resize
+        if (!vx.state.in_band_resize) try loop.init();
+    }
+
+    // HACK: Ghostty is reporting incorrect pixel screen size
+    vx.caps.sgr_pixels = false;
+    try vx.setMouseMode(tty.anyWriter(), true);
+
+    // Give DrawContext the unicode data
+    vxfw.DrawContext.init(&vx.unicode, vx.screen.width_method);
+
+    const framerate: u64 = if (opts.framerate > 0) opts.framerate else 60;
+    // Calculate tick rate
+    const tick_ms: u64 = @divFloor(std.time.ms_per_s, framerate);
+
+    // Set up arena and context
+    var arena = std.heap.ArenaAllocator.init(self.allocator);
+    defer arena.deinit();
+
+    var buffered = tty.bufferedWriter();
+
+    var mouse_handler = MouseHandler.init(widget);
+    var focus_handler = FocusHandler.init(self.allocator, widget);
+    focus_handler.intrusiveInit();
+    defer focus_handler.deinit();
+
+    // Timestamp of our next frame
+    var next_frame_ms: u64 = @intCast(std.time.milliTimestamp());
+
+    // Create our event context
+    var ctx: vxfw.EventContext = .{
+        .phase = .at_target,
+        .cmds = vxfw.CommandList.init(self.allocator),
+        .consume_event = false,
+        .redraw = false,
+        .quit = false,
+    };
+    defer ctx.cmds.deinit();
+
+    while (true) {
+        const now_ms: u64 = @intCast(std.time.milliTimestamp());
+        if (now_ms >= next_frame_ms) {
+            // Deadline exceeded. Schedule the next frame
+            next_frame_ms = now_ms + tick_ms;
+        } else {
+            // Sleep until the deadline
+            std.time.sleep((next_frame_ms - now_ms) * std.time.ns_per_ms);
+            next_frame_ms += tick_ms;
+        }
+
+        try self.checkTimers(&ctx);
+
+        while (loop.tryEvent()) |event| {
+            ctx.consume_event = false;
+            switch (event) {
+                .key_press => |key| {
+                    try focus_handler.handleEvent(&ctx, event);
+                    try self.handleCommand(&ctx.cmds);
+                    if (!ctx.consume_event) {
+                        if (key.matches(self.quit_key.codepoint, self.quit_key.mods)) {
+                            ctx.quit = true;
+                        }
+                        if (key.matches(vaxis.Key.tab, .{})) {
+                            try focus_handler.focusNext(&ctx);
+                            try self.handleCommand(&ctx.cmds);
+                        }
+                        if (key.matches(vaxis.Key.tab, .{ .shift = true })) {
+                            try focus_handler.focusPrev(&ctx);
+                            try self.handleCommand(&ctx.cmds);
+                        }
+                    }
+                },
+                .focus_out => try mouse_handler.mouseExit(self, &ctx),
+                .mouse => |mouse| try mouse_handler.handleMouse(self, &ctx, mouse),
+                .winsize => |ws| {
+                    try vx.resize(self.allocator, buffered.writer().any(), ws);
+                    try buffered.flush();
+                    ctx.redraw = true;
+                },
+                else => {
+                    try widget.handleEvent(&ctx, event);
+                    try self.handleCommand(&ctx.cmds);
+                },
+            }
+        }
+
+        // Check if we should quit
+        if (ctx.quit) return;
+
+        // Check if we need a redraw
+        if (!ctx.redraw) continue;
+        ctx.redraw = false;
+        // Assert that we have handled all commands
+        assert(ctx.cmds.items.len == 0);
+
+        _ = arena.reset(.retain_capacity);
+
+        const draw_context: vxfw.DrawContext = .{
+            .arena = arena.allocator(),
+            .min = .{ .width = 0, .height = 0 },
+            .max = .{
+                .width = @intCast(vx.screen.width),
+                .height = @intCast(vx.screen.height),
+            },
+        };
+        const win = vx.window();
+        win.clear();
+        win.hideCursor();
+        win.setCursorShape(.default);
+        const surface = try widget.draw(draw_context);
+
+        const focused = self.wants_focus orelse focus_handler.focused.widget;
+        surface.render(win, focused);
+        try vx.render(buffered.writer().any());
+        try buffered.flush();
+
+        // Store the last frame
+        mouse_handler.last_frame = surface;
+        try focus_handler.update(surface, self.wants_focus);
+        self.wants_focus = null;
+    }
+}
+
+fn addTick(self: *App, tick: vxfw.Tick) Allocator.Error!void {
+    try self.timers.append(tick);
+    std.sort.insertion(vxfw.Tick, self.timers.items, {}, vxfw.Tick.lessThan);
+}
+
+fn handleCommand(self: *App, cmds: *vxfw.CommandList) Allocator.Error!void {
+    defer cmds.clearRetainingCapacity();
+    for (cmds.items) |cmd| {
+        switch (cmd) {
+            .tick => |tick| try self.addTick(tick),
+            .set_mouse_shape => |shape| self.vx.setMouseShape(shape),
+            .request_focus => |widget| self.wants_focus = widget,
+        }
+    }
+}
+
+fn checkTimers(self: *App, ctx: *vxfw.EventContext) anyerror!void {
+    const now_ms = std.time.milliTimestamp();
+
+    // timers are always sorted descending
+    while (self.timers.popOrNull()) |tick| {
+        if (now_ms < tick.deadline_ms)
+            break;
+        try tick.widget.handleEvent(ctx, .tick);
+        try self.handleCommand(&ctx.cmds);
+    }
+}
+
+const MouseHandler = struct {
+    last_frame: vxfw.Surface,
+    maybe_last_handler: ?vxfw.Widget = null,
+
+    fn init(root: Widget) MouseHandler {
+        return .{
+            .last_frame = .{
+                .size = .{ .width = 0, .height = 0 },
+                .widget = root,
+                .buffer = &.{},
+                .children = &.{},
+            },
+            .maybe_last_handler = null,
+        };
+    }
+
+    fn handleMouse(self: *MouseHandler, app: *App, ctx: *vxfw.EventContext, mouse: vaxis.Mouse) anyerror!void {
+        const last_frame = self.last_frame;
+
+        // For mouse events we store the last frame and use that for hit testing
+        var hits = std.ArrayList(vxfw.HitResult).init(app.allocator);
+        defer hits.deinit();
+        const sub: vxfw.SubSurface = .{
+            .origin = .{ .row = 0, .col = 0 },
+            .surface = last_frame,
+            .z_index = 0,
+        };
+        const mouse_point: vxfw.Point = .{
+            .row = @intCast(mouse.row),
+            .col = @intCast(mouse.col),
+        };
+        if (sub.containsPoint(mouse_point)) {
+            try last_frame.hitTest(&hits, mouse_point);
+        }
+        while (hits.popOrNull()) |item| {
+            var m_local = mouse;
+            m_local.col = item.local.col;
+            m_local.row = item.local.row;
+            try item.widget.handleEvent(ctx, .{ .mouse = m_local });
+            try app.handleCommand(&ctx.cmds);
+
+            // If the event wasn't consumed, we keep passing it on
+            if (!ctx.consume_event) continue;
+
+            if (self.maybe_last_handler) |last_mouse_handler| {
+                if (!last_mouse_handler.eql(item.widget)) {
+                    try last_mouse_handler.handleEvent(ctx, .mouse_leave);
+                    try app.handleCommand(&ctx.cmds);
+                }
+            }
+            self.maybe_last_handler = item.widget;
+            return;
+        }
+
+        // If no one handled the mouse, we assume it exited
+        return self.mouseExit(app, ctx);
+    }
+
+    fn mouseExit(self: *MouseHandler, app: *App, ctx: *vxfw.EventContext) anyerror!void {
+        if (self.maybe_last_handler) |last_handler| {
+            try last_handler.handleEvent(ctx, .mouse_leave);
+            try app.handleCommand(&ctx.cmds);
+            self.maybe_last_handler = null;
+        }
+    }
+};
+
+/// Maintains a tree of focusable nodes. Delivers events to the currently focused node, walking up
+/// the tree until the event is handled
+const FocusHandler = struct {
+    arena: std.heap.ArenaAllocator,
+
+    root: Node,
+    focused: *Node,
+    maybe_wants_focus: ?vxfw.Widget = null,
+
+    const Node = struct {
+        widget: Widget,
+        parent: ?*Node,
+        children: []*Node,
+
+        fn nextSibling(self: Node) ?*Node {
+            const parent = self.parent orelse return null;
+            const idx = for (0..parent.children.len) |i| {
+                const node = parent.children[i];
+                if (self.widget.eql(node.widget))
+                    break i;
+            } else unreachable;
+
+            // Return null if last child
+            if (idx == parent.children.len - 1)
+                return null
+            else
+                return parent.children[idx + 1];
+        }
+
+        fn prevSibling(self: Node) ?*Node {
+            const parent = self.parent orelse return null;
+            const idx = for (0..parent.children.len) |i| {
+                const node = parent.children[i];
+                if (self.widget.eql(node.widget))
+                    break i;
+            } else unreachable;
+
+            // Return null if first child
+            if (idx == 0)
+                return null
+            else
+                return parent.children[idx - 1];
+        }
+
+        fn lastChild(self: Node) ?*Node {
+            if (self.children.len > 0)
+                return self.children[self.children.len - 1]
+            else
+                return null;
+        }
+
+        fn firstChild(self: Node) ?*Node {
+            if (self.children.len > 0)
+                return self.children[0]
+            else
+                return null;
+        }
+
+        /// returns the next logical node in the tree
+        fn nextNode(self: *Node) *Node {
+            // If we have a sibling, we return it's first descendant line
+            if (self.nextSibling()) |sibling| {
+                var node = sibling;
+                while (node.firstChild()) |child| {
+                    node = child;
+                }
+                return node;
+            }
+
+            // If we don't have a sibling, we return our parent
+            if (self.parent) |parent| return parent;
+
+            // If we don't have a parent, we are the root and we return or first descendant
+            var node = self;
+            while (node.firstChild()) |child| {
+                node = child;
+            }
+            return node;
+        }
+
+        fn prevNode(self: *Node) *Node {
+            // If we have children, we return the last child descendant
+            if (self.children.len > 0) {
+                var node = self;
+                while (node.lastChild()) |child| {
+                    node = child;
+                }
+                return node;
+            }
+
+            // If we have siblings, we return the last descendant line of the sibling
+            if (self.prevSibling()) |sibling| {
+                var node = sibling;
+                while (node.lastChild()) |child| {
+                    node = child;
+                }
+                return node;
+            }
+
+            // If we don't have a sibling, we return our parent
+            if (self.parent) |parent| return parent;
+
+            // If we don't have a parent, we are the root and we return our last descendant
+            var node = self;
+            while (node.lastChild()) |child| {
+                node = child;
+            }
+            return node;
+        }
+    };
+
+    fn init(allocator: Allocator, root: Widget) FocusHandler {
+        const node: Node = .{
+            .widget = root,
+            .parent = null,
+            .children = &.{},
+        };
+        return .{
+            .root = node,
+            .focused = undefined,
+            .arena = std.heap.ArenaAllocator.init(allocator),
+            .maybe_wants_focus = null,
+        };
+    }
+
+    fn intrusiveInit(self: *FocusHandler) void {
+        self.focused = &self.root;
+    }
+
+    fn deinit(self: *FocusHandler) void {
+        self.arena.deinit();
+    }
+
+    /// Update the focus list
+    fn update(self: *FocusHandler, root: vxfw.Surface, maybe_wants_focus: ?vxfw.Widget) Allocator.Error!void {
+        _ = self.arena.reset(.retain_capacity);
+        self.maybe_wants_focus = maybe_wants_focus;
+
+        var list = std.ArrayList(*Node).init(self.arena.allocator());
+        for (root.children) |child| {
+            try self.findFocusableChildren(&self.root, &list, child.surface);
+        }
+        self.root = .{
+            .widget = root.widget,
+            .children = list.items,
+            .parent = null,
+        };
+    }
+
+    /// Walks the surface tree, adding all focusable nodes to list
+    fn findFocusableChildren(
+        self: *FocusHandler,
+        parent: *Node,
+        list: *std.ArrayList(*Node),
+        surface: vxfw.Surface,
+    ) Allocator.Error!void {
+        if (surface.focusable) {
+            // We are a focusable child of parent. Create a new node, and find our own focusable
+            // children
+            const node = try self.arena.allocator().create(Node);
+            var child_list = std.ArrayList(*Node).init(self.arena.allocator());
+            for (surface.children) |child| {
+                try self.findFocusableChildren(node, &child_list, child.surface);
+            }
+            node.* = .{
+                .widget = surface.widget,
+                .parent = parent,
+                .children = child_list.items,
+            };
+            if (self.maybe_wants_focus) |wants_focus| {
+                if (wants_focus.eql(surface.widget)) {
+                    self.focused = node;
+                    self.maybe_wants_focus = null;
+                }
+            }
+            try list.append(node);
+        } else {
+            for (surface.children) |child| {
+                try self.findFocusableChildren(parent, list, child.surface);
+            }
+        }
+    }
+
+    fn focusNode(self: *FocusHandler, ctx: *vxfw.EventContext, node: *Node) anyerror!void {
+        if (self.focused.widget.eql(node.widget)) return;
+
+        try self.focused.widget.handleEvent(ctx, .focus_out);
+        self.focused = node;
+        try self.focused.widget.handleEvent(ctx, .focus_in);
+    }
+
+    /// Focuses the next focusable widget
+    fn focusNext(self: *FocusHandler, ctx: *vxfw.EventContext) anyerror!void {
+        return self.focusNode(ctx, self.focused.nextNode());
+    }
+
+    /// Focuses the previous focusable widget
+    fn focusPrev(self: *FocusHandler, ctx: *vxfw.EventContext) anyerror!void {
+        return self.focusNode(ctx, self.focused.prevNode());
+    }
+
+    fn handleEvent(self: *FocusHandler, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        var maybe_node: ?*Node = self.focused;
+        while (maybe_node) |node| {
+            try node.widget.handleEvent(ctx, event);
+            if (ctx.consume_event) return;
+            maybe_node = node.parent;
+        }
+    }
+};

--- a/src/vxfw/Button.zig
+++ b/src/vxfw/Button.zig
@@ -1,0 +1,216 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const vxfw = @import("vxfw.zig");
+
+const Allocator = std.mem.Allocator;
+
+const Center = @import("Center.zig");
+const Text = @import("Text.zig");
+
+const Button = @This();
+
+// User supplied values
+label: []const u8,
+onClick: *const fn (?*anyopaque, ctx: *vxfw.EventContext) anyerror!void,
+userdata: ?*anyopaque = null,
+
+// Styles
+style: struct {
+    default: vaxis.Style = .{ .reverse = true },
+    mouse_down: vaxis.Style = .{ .fg = .{ .index = 4 }, .reverse = true },
+    hover: vaxis.Style = .{ .fg = .{ .index = 3 }, .reverse = true },
+    focus: vaxis.Style = .{ .fg = .{ .index = 5 }, .reverse = true },
+} = .{},
+
+// State
+mouse_down: bool = false,
+has_mouse: bool = false,
+focused: bool = false,
+
+pub fn widget(self: *Button) vxfw.Widget {
+    return .{
+        .userdata = self,
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *Button = @ptrCast(@alignCast(ptr));
+    return self.handleEvent(ctx, event);
+}
+
+pub fn handleEvent(self: *Button, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    switch (event) {
+        .key_press => |key| {
+            if (key.matches(vaxis.Key.enter, .{})) {
+                return self.doClick(ctx);
+            }
+        },
+        .mouse => |mouse| {
+            if (self.mouse_down and mouse.type == .release) {
+                self.mouse_down = false;
+                return self.doClick(ctx);
+            }
+            if (mouse.type == .press and mouse.button == .left) {
+                self.mouse_down = true;
+                return ctx.consumeAndRedraw();
+            }
+            if (!self.has_mouse) {
+                self.has_mouse = true;
+
+                // implicit redraw
+                try ctx.setMouseShape(.pointer);
+                return ctx.consumeAndRedraw();
+            }
+            return ctx.consumeEvent();
+        },
+        .mouse_leave => {
+            self.has_mouse = false;
+            self.mouse_down = false;
+            // implicit redraw
+            try ctx.setMouseShape(.default);
+        },
+        .focus_in => {
+            self.focused = true;
+            ctx.redraw = true;
+        },
+        .focus_out => {
+            self.focused = false;
+            ctx.redraw = true;
+        },
+        else => {},
+    }
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *Button = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *Button, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const style: vaxis.Style = if (self.mouse_down)
+        self.style.mouse_down
+    else if (self.has_mouse)
+        self.style.hover
+    else if (self.focused)
+        self.style.focus
+    else
+        self.style.default;
+
+    const text: Text = .{
+        .style = style,
+        .text = self.label,
+        .text_align = .center,
+    };
+
+    const center: Center = .{ .child = text.widget() };
+    const surf = try center.draw(ctx);
+
+    var button_surf = try vxfw.Surface.initWithChildren(ctx.arena, self.widget(), surf.size, surf.children);
+    @memset(button_surf.buffer, .{ .style = style });
+    button_surf.handles_mouse = true;
+    button_surf.focusable = true;
+    return button_surf;
+}
+
+fn doClick(self: *Button, ctx: *vxfw.EventContext) anyerror!void {
+    try self.onClick(self.userdata, ctx);
+    ctx.consume_event = true;
+}
+
+test Button {
+    // Create some object which reacts to a button press
+    const Foo = struct {
+        count: u8,
+
+        fn onClick(ptr: ?*anyopaque, ctx: *vxfw.EventContext) anyerror!void {
+            const foo: *@This() = @ptrCast(@alignCast(ptr));
+            foo.count +|= 1;
+            ctx.consumeAndRedraw();
+        }
+    };
+    var foo: Foo = .{ .count = 0 };
+
+    var button: Button = .{
+        .label = "Test Button",
+        .onClick = Foo.onClick,
+        .userdata = &foo,
+    };
+
+    // Event handlers need a context
+    var ctx: vxfw.EventContext = .{
+        .cmds = std.ArrayList(vxfw.Command).init(std.testing.allocator),
+    };
+    defer ctx.cmds.deinit();
+
+    // Get the widget interface
+    const b_widget = button.widget();
+
+    // Create a synthetic mouse event
+    var mouse_event: vaxis.Mouse = .{
+        .col = 0,
+        .row = 0,
+        .mods = .{},
+        .button = .left,
+        .type = .press,
+    };
+    // Send the button a mouse press event
+    try b_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+
+    // A press alone doesn't trigger onClick
+    try std.testing.expectEqual(0, foo.count);
+
+    // Send the button a mouse release event. The onClick handler is called
+    mouse_event.type = .release;
+    try b_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    try std.testing.expectEqual(1, foo.count);
+
+    // Send it another press
+    mouse_event.type = .press;
+    try b_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+
+    // Now the mouse leaves
+    try b_widget.handleEvent(&ctx, .mouse_leave);
+
+    // Then it comes back. We don't know it but the button was pressed outside of our widget. We
+    // receie the release event
+    mouse_event.type = .release;
+    try b_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+
+    // But we didn't have the press registered, so we don't call onClick
+    try std.testing.expectEqual(1, foo.count);
+
+    // Now we receive an enter keypress. This also triggers the onClick handler
+    try b_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.enter } });
+    try std.testing.expectEqual(2, foo.count);
+
+    // Now we draw the button. Set up our context with some unicode data
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    const draw_ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 13, .height = 3 },
+    };
+    const surface = try b_widget.draw(draw_ctx);
+
+    // The button should fill the available space.
+    try std.testing.expectEqual(surface.size.width, draw_ctx.max.width.?);
+    try std.testing.expectEqual(surface.size.height, draw_ctx.max.height.?);
+
+    // It should have one child, the label
+    try std.testing.expectEqual(1, surface.children.len);
+
+    // The label should be centered
+    try std.testing.expectEqual(1, surface.children[0].origin.row);
+    try std.testing.expectEqual(1, surface.children[0].origin.col);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/Center.zig
+++ b/src/vxfw/Center.zig
@@ -1,0 +1,118 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const Center = @This();
+
+child: vxfw.Widget,
+
+pub fn widget(self: *const Center) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *const Center = @ptrCast(@alignCast(ptr));
+    return self.child.handleEvent(ctx, event);
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *const Center = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+/// Cannot have unbounded constraints
+pub fn draw(self: *const Center, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const child_ctx = ctx.withConstraints(.{ .width = 0, .height = 0 }, ctx.max);
+    const max_size = ctx.max.size();
+    const child = try self.child.draw(child_ctx);
+
+    const x = (max_size.width - child.size.width) / 2;
+    const y = (max_size.height - child.size.height) / 2;
+
+    const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+    children[0] = .{
+        .origin = .{ .col = x, .row = y },
+        .z_index = 0,
+        .surface = child,
+    };
+
+    return .{
+        .size = max_size,
+        .widget = self.widget(),
+        .buffer = &.{},
+        .children = children,
+    };
+}
+
+test Center {
+    const Text = @import("Text.zig");
+    // Will be height=1, width=3
+    const text: Text = .{ .text = "abc" };
+
+    const center: Center = .{ .child = text.widget() };
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    {
+        // Center expands to the max size. It must therefore have non-null max width and max height.
+        // These values are asserted in draw
+        const ctx: vxfw.DrawContext = .{
+            .arena = arena.allocator(),
+            .min = .{},
+            .max = .{ .width = 10, .height = 10 },
+        };
+
+        const surface = try center.draw(ctx);
+        // Center does not produce any drawable cells
+        try std.testing.expectEqual(0, surface.buffer.len);
+        // Center has 1 child
+        try std.testing.expectEqual(1, surface.children.len);
+        // Center is the max size
+        try std.testing.expectEqual(surface.size, ctx.max.size());
+        const child = surface.children[0];
+        // The child is 1x3
+        try std.testing.expectEqual(3, child.surface.size.width);
+        try std.testing.expectEqual(1, child.surface.size.height);
+        // A centered 1x3 in 10x10 should be at origin 3, 4. The bias is toward the top left corner
+        try std.testing.expectEqual(4, child.origin.row);
+        try std.testing.expectEqual(3, child.origin.col);
+    }
+    {
+        // Center expands to the max size. It must therefore have non-null max width and max height.
+        // These values are asserted in draw
+        const ctx: vxfw.DrawContext = .{
+            .arena = arena.allocator(),
+            .min = .{},
+            .max = .{ .width = 5, .height = 3 },
+        };
+
+        const surface = try center.draw(ctx);
+        // Center does not produce any drawable cells
+        try std.testing.expectEqual(0, surface.buffer.len);
+        // Center has 1 child
+        try std.testing.expectEqual(1, surface.children.len);
+        // Center is the max size
+        try std.testing.expectEqual(surface.size, ctx.max.size());
+        const child = surface.children[0];
+        // The child is 1x3
+        try std.testing.expectEqual(3, child.surface.size.width);
+        try std.testing.expectEqual(1, child.surface.size.height);
+        // A centered 1x3 in 3x5 should be at origin 1, 1. This is a perfectly centered child
+        try std.testing.expectEqual(1, child.origin.row);
+        try std.testing.expectEqual(1, child.origin.col);
+    }
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/FlexColumn.zig
+++ b/src/vxfw/FlexColumn.zig
@@ -1,0 +1,162 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const FlexColumn = @This();
+
+children: []const vxfw.FlexItem,
+
+pub fn widget(self: *const FlexColumn) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = vxfw.noopEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *const FlexColumn = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *const FlexColumn, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    std.debug.assert(ctx.max.height != null);
+    std.debug.assert(ctx.max.width != null);
+    if (self.children.len == 0) return vxfw.Surface.init(ctx.arena, self.widget(), ctx.min);
+
+    // Store the inherent size of each widget
+    const size_list = try ctx.arena.alloc(u16, self.children.len);
+
+    var layout_arena = std.heap.ArenaAllocator.init(ctx.arena);
+
+    const layout_ctx: vxfw.DrawContext = .{
+        .min = .{ .width = 0, .height = 0 },
+        .max = .{ .width = ctx.max.width, .height = null },
+        .arena = layout_arena.allocator(),
+    };
+
+    // Store the inherent size of each widget
+    var first_pass_height: u16 = 0;
+    var total_flex: u16 = 0;
+    for (self.children, 0..) |child, i| {
+        const surf = try child.widget.draw(layout_ctx);
+        first_pass_height += surf.size.height;
+        total_flex += child.flex;
+        size_list[i] = surf.size.height;
+    }
+
+    // We are done with the layout arena
+    layout_arena.deinit();
+
+    // make our children list
+    var children = std.ArrayList(vxfw.SubSurface).init(ctx.arena);
+
+    // Draw again, but with distributed heights
+    var second_pass_height: u16 = 0;
+    var max_width: u16 = 0;
+    const remaining_space = ctx.max.height.? - first_pass_height;
+    for (self.children, 1..) |child, i| {
+        const inherent_height = size_list[i - 1];
+        const child_height = if (child.flex == 0)
+            inherent_height
+        else if (i == self.children.len)
+            // If we are the last one, we just get the remainder
+            ctx.max.height.? - second_pass_height
+        else
+            inherent_height + (remaining_space * child.flex) / total_flex;
+
+        // Create a context for the child
+        const child_ctx = ctx.withConstraints(
+            .{ .width = 0, .height = child_height },
+            .{ .width = ctx.max.width.?, .height = child_height },
+        );
+        const surf = try child.widget.draw(child_ctx);
+
+        try children.append(.{
+            .origin = .{ .col = 0, .row = second_pass_height },
+            .surface = surf,
+            .z_index = 0,
+        });
+        max_width = @max(max_width, surf.size.width);
+        second_pass_height += surf.size.height;
+    }
+
+    const size = .{ .width = max_width, .height = second_pass_height };
+    return .{
+        .size = size,
+        .widget = self.widget(),
+        .buffer = &.{},
+        .children = children.items,
+    };
+}
+
+test FlexColumn {
+    // Create child widgets
+    const Text = @import("Text.zig");
+    // Will be height=1, width=3
+    const abc: Text = .{ .text = "abc" };
+    const def: Text = .{ .text = "def" };
+    const ghi: Text = .{ .text = "ghi" };
+    const jklmno: Text = .{ .text = "jkl\nmno" };
+
+    // Create the flex column
+    const flex_column: FlexColumn = .{
+        .children = &.{
+            .{ .widget = abc.widget(), .flex = 0 }, // flex=0 means we are our inherent size
+            .{ .widget = def.widget(), .flex = 1 },
+            .{ .widget = ghi.widget(), .flex = 1 },
+            .{ .widget = jklmno.widget(), .flex = 1 },
+        },
+    };
+
+    // Boiler plate draw context
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    const flex_widget = flex_column.widget();
+    const ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 16, .height = 16 },
+    };
+
+    const surface = try flex_widget.draw(ctx);
+    // FlexColumn expands to max height and widest child
+    try std.testing.expectEqual(16, surface.size.height);
+    try std.testing.expectEqual(3, surface.size.width);
+    // We have four children
+    try std.testing.expectEqual(4, surface.children.len);
+
+    // We will track the row we are on to confirm the origins
+    var row: u16 = 0;
+    // First child has flex=0, it should be it's inherent height
+    try std.testing.expectEqual(1, surface.children[0].surface.size.height);
+    try std.testing.expectEqual(row, surface.children[0].origin.row);
+    // Add the child height each time
+    row += surface.children[0].surface.size.height;
+    // Let's do some math
+    // - We have 4 children to fit into 16 rows. 3 children will be 1 row tall, one will be 2 rows
+    //   tall for a total height of 5 rows.
+    // - The first child is 1 row and no flex. The rest of the height gets distributed evenly among
+    //   the remaining 3 children. The remainder height is 16 - 5 = 11, so each child should get 11 /
+    //   3 = 3 extra rows, and the last will receive the remainder
+    try std.testing.expectEqual(1 + 3, surface.children[1].surface.size.height);
+    try std.testing.expectEqual(row, surface.children[1].origin.row);
+    row += surface.children[1].surface.size.height;
+
+    try std.testing.expectEqual(1 + 3, surface.children[2].surface.size.height);
+    try std.testing.expectEqual(row, surface.children[2].origin.row);
+    row += surface.children[2].surface.size.height;
+
+    try std.testing.expectEqual(2 + 3 + 2, surface.children[3].surface.size.height);
+    try std.testing.expectEqual(row, surface.children[3].origin.row);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/FlexRow.zig
+++ b/src/vxfw/FlexRow.zig
@@ -1,0 +1,159 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const vxfw = @import("vxfw.zig");
+
+const Allocator = std.mem.Allocator;
+
+const FlexRow = @This();
+
+children: []const vxfw.FlexItem,
+
+pub fn widget(self: *const FlexRow) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = vxfw.noopEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *const FlexRow = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *const FlexRow, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    std.debug.assert(ctx.max.height != null);
+    std.debug.assert(ctx.max.width != null);
+    if (self.children.len == 0) return vxfw.Surface.init(ctx.arena, self.widget(), ctx.min);
+
+    // Store the inherent size of each widget
+    const size_list = try ctx.arena.alloc(u16, self.children.len);
+
+    var layout_arena = std.heap.ArenaAllocator.init(ctx.arena);
+
+    const layout_ctx: vxfw.DrawContext = .{
+        .min = .{ .width = 0, .height = 0 },
+        .max = .{ .width = null, .height = ctx.max.height },
+        .arena = layout_arena.allocator(),
+    };
+
+    var first_pass_width: u16 = 0;
+    var total_flex: u16 = 0;
+    for (self.children, 0..) |child, i| {
+        const surf = try child.widget.draw(layout_ctx);
+        first_pass_width += surf.size.width;
+        total_flex += child.flex;
+        size_list[i] = surf.size.width;
+    }
+
+    // We are done with the layout arena
+    layout_arena.deinit();
+
+    // make our children list
+    var children = std.ArrayList(vxfw.SubSurface).init(ctx.arena);
+
+    // Draw again, but with distributed widths
+    var second_pass_width: u16 = 0;
+    var max_height: u16 = 0;
+    const remaining_space = ctx.max.width.? - first_pass_width;
+    for (self.children, 1..) |child, i| {
+        const inherent_width = size_list[i - 1];
+        const child_width = if (child.flex == 0)
+            inherent_width
+        else if (i == self.children.len)
+            // If we are the last one, we just get the remainder
+            ctx.max.width.? - second_pass_width
+        else
+            inherent_width + (remaining_space * child.flex) / total_flex;
+
+        // Create a context for the child
+        const child_ctx = ctx.withConstraints(
+            .{ .width = child_width, .height = 0 },
+            .{ .width = child_width, .height = ctx.max.height.? },
+        );
+        const surf = try child.widget.draw(child_ctx);
+
+        try children.append(.{
+            .origin = .{ .col = second_pass_width, .row = 0 },
+            .surface = surf,
+            .z_index = 0,
+        });
+        max_height = @max(max_height, surf.size.height);
+        second_pass_width += surf.size.width;
+    }
+    const size = .{ .width = second_pass_width, .height = max_height };
+    return .{
+        .size = size,
+        .widget = self.widget(),
+        .buffer = &.{},
+        .children = children.items,
+    };
+}
+
+test FlexRow {
+    // Create child widgets
+    const Text = @import("Text.zig");
+    // Will be height=1, width=3
+    const abc: Text = .{ .text = "abc" };
+    const def: Text = .{ .text = "def" };
+    const ghi: Text = .{ .text = "ghi" };
+    const jklmno: Text = .{ .text = "jkl\nmno" };
+
+    // Create the flex row
+    const flex_row: FlexRow = .{
+        .children = &.{
+            .{ .widget = abc.widget(), .flex = 0 }, // flex=0 means we are our inherent size
+            .{ .widget = def.widget(), .flex = 1 },
+            .{ .widget = ghi.widget(), .flex = 1 },
+            .{ .widget = jklmno.widget(), .flex = 1 },
+        },
+    };
+
+    // Boiler plate draw context
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    const flex_widget = flex_row.widget();
+    const ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 16, .height = 16 },
+    };
+
+    const surface = try flex_widget.draw(ctx);
+    // FlexRow expands to max width and tallest child
+    try std.testing.expectEqual(16, surface.size.width);
+    try std.testing.expectEqual(2, surface.size.height);
+    // We have four children
+    try std.testing.expectEqual(4, surface.children.len);
+
+    // We will track the column we are on to confirm the origins
+    var col: u16 = 0;
+    // First child has flex=0, it should be it's inherent width
+    try std.testing.expectEqual(3, surface.children[0].surface.size.width);
+    try std.testing.expectEqual(col, surface.children[0].origin.col);
+    // Add the child height each time
+    col += surface.children[0].surface.size.width;
+    // Let's do some math
+    // - We have 4 children to fit into 16 cols. All children will be 3 wide for a total width of 12
+    // - The first child is 3 cols and no flex. The rest of the width gets distributed evenly among
+    //   the remaining 3 children. The remainder width is 16 - 12 = 4, so each child should get 4 /
+    //   3 = 1 extra cols, and the last will receive the remainder
+    try std.testing.expectEqual(1 + 3, surface.children[1].surface.size.width);
+    try std.testing.expectEqual(col, surface.children[1].origin.col);
+    col += surface.children[1].surface.size.width;
+
+    try std.testing.expectEqual(1 + 3, surface.children[2].surface.size.width);
+    try std.testing.expectEqual(col, surface.children[2].origin.col);
+    col += surface.children[2].surface.size.width;
+
+    try std.testing.expectEqual(1 + 3 + 1, surface.children[3].surface.size.width);
+    try std.testing.expectEqual(col, surface.children[3].origin.col);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/ListView.zig
+++ b/src/vxfw/ListView.zig
@@ -1,0 +1,686 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const assert = std.debug.assert;
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const ListView = @This();
+
+pub const Builder = struct {
+    userdata: *const anyopaque,
+    buildFn: *const fn (*const anyopaque, idx: usize, cursor: usize) ?vxfw.Widget,
+
+    inline fn itemAtIdx(self: Builder, idx: usize, cursor: usize) ?vxfw.Widget {
+        return self.buildFn(self.userdata, idx, cursor);
+    }
+};
+
+pub const Source = union(enum) {
+    slice: []const vxfw.Widget,
+    builder: Builder,
+};
+
+const Scroll = struct {
+    /// Index of the first fully-in-view widget
+    top: u32 = 0,
+    /// Line offset within the top widget.
+    offset: i17 = 0,
+    /// Pending scroll amount
+    pending_lines: i17 = 0,
+    /// If there is more room to scroll down
+    has_more: bool = true,
+    /// The cursor must be in the viewport
+    wants_cursor: bool = false,
+
+    fn linesDown(self: *Scroll, n: u8) bool {
+        if (!self.has_more) return false;
+        self.pending_lines += n;
+        return true;
+    }
+
+    fn linesUp(self: *Scroll, n: u8) bool {
+        if (self.top == 0 and self.offset == 0) return false;
+        self.pending_lines = -1 * @as(i17, @intCast(n));
+        return true;
+    }
+};
+
+const cursor_indicator: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } };
+
+children: Source,
+cursor: u32 = 0,
+/// When true, the widget will draw a cursor next to the widget which has the cursor
+draw_cursor: bool = true,
+/// Lines to scroll for a mouse wheel
+wheel_scroll: u8 = 3,
+/// Set this if the exact item count is known.
+item_count: ?u32 = null,
+
+/// scroll position
+scroll: Scroll = .{},
+
+pub fn widget(self: *const ListView) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *ListView = @ptrCast(@alignCast(ptr));
+    return self.handleEvent(ctx, event);
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *ListView = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn handleEvent(self: *ListView, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    switch (event) {
+        .mouse => |mouse| {
+            if (mouse.button == .wheel_up) {
+                if (self.scroll.linesUp(self.wheel_scroll))
+                    ctx.consumeAndRedraw();
+            }
+            if (mouse.button == .wheel_down) {
+                if (self.scroll.linesDown(self.wheel_scroll))
+                    ctx.consumeAndRedraw();
+            }
+        },
+        .key_press => |key| {
+            if (key.matches('j', .{}) or
+                key.matches('n', .{ .ctrl = true }) or
+                key.matches(vaxis.Key.down, .{}))
+            {
+                return self.nextItem(ctx);
+            }
+            if (key.matches('k', .{}) or
+                key.matches('p', .{ .ctrl = true }) or
+                key.matches(vaxis.Key.up, .{}))
+            {
+                return self.prevItem(ctx);
+            }
+            if (key.matches(vaxis.Key.escape, .{})) {
+                self.ensureScroll();
+                return ctx.consumeAndRedraw();
+            }
+
+            // All other keypresses go to our focused child
+            switch (self.children) {
+                .slice => |slice| {
+                    const child = slice[self.cursor];
+                    return child.handleEvent(ctx, event);
+                },
+                .builder => |builder| {
+                    if (builder.itemAtIdx(self.cursor, self.cursor)) |child| {
+                        return child.handleEvent(ctx, event);
+                    }
+                },
+            }
+        },
+        else => {},
+    }
+}
+
+pub fn draw(self: *ListView, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    std.debug.assert(ctx.max.width != null);
+    std.debug.assert(ctx.max.height != null);
+    switch (self.children) {
+        .slice => |slice| {
+            self.item_count = @intCast(slice.len);
+            const builder: SliceBuilder = .{ .slice = slice };
+            return self.drawBuilder(ctx, .{ .userdata = &builder, .buildFn = SliceBuilder.build });
+        },
+        .builder => |b| return self.drawBuilder(ctx, b),
+    }
+}
+
+pub fn nextItem(self: *ListView, ctx: *vxfw.EventContext) void {
+    // If we have a count, we can handle this directly
+    if (self.item_count) |count| {
+        if (self.cursor >= count - 1) {
+            return ctx.consumeEvent();
+        }
+        self.cursor += 1;
+    } else {
+        switch (self.children) {
+            .slice => |slice| {
+                self.item_count = @intCast(slice.len);
+                // If we are already at the end, don't do anything
+                if (self.cursor == slice.len - 1) {
+                    return ctx.consumeEvent();
+                }
+                // Advance the cursor
+                self.cursor += 1;
+            },
+            .builder => |builder| {
+                // Save our current state
+                const prev = self.cursor;
+                // Advance the cursor
+                self.cursor += 1;
+                // Check the bounds, reversing until we get the last item
+                while (builder.itemAtIdx(self.cursor, self.cursor) == null) {
+                    self.cursor -|= 1;
+                }
+                // If we didn't change state, we don't redraw
+                if (self.cursor == prev) {
+                    return ctx.consumeEvent();
+                }
+            },
+        }
+    }
+    // Reset scroll
+    self.ensureScroll();
+    ctx.consumeAndRedraw();
+}
+
+pub fn prevItem(self: *ListView, ctx: *vxfw.EventContext) void {
+    if (self.cursor == 0) {
+        return ctx.consumeEvent();
+    }
+
+    if (self.item_count) |count| {
+        // If for some reason our count changed, we handle it here
+        self.cursor = @min(self.cursor - 1, count - 1);
+    } else {
+        switch (self.children) {
+            .slice => |slice| {
+                self.item_count = @intCast(slice.len);
+                self.cursor = @min(self.cursor - 1, slice.len - 1);
+            },
+            .builder => |builder| {
+                // Save our current state
+                const prev = self.cursor;
+                // Decrement the cursor
+                self.cursor -= 1;
+                // Check the bounds, reversing until we get the last item
+                while (builder.itemAtIdx(self.cursor, self.cursor) == null) {
+                    self.cursor -|= 1;
+                }
+                // If we didn't change state, we don't redraw
+                if (self.cursor == prev) {
+                    return ctx.consumeEvent();
+                }
+            },
+        }
+    }
+
+    // Reset scroll
+    self.ensureScroll();
+    return ctx.consumeAndRedraw();
+}
+
+// Only call when cursor state has changed, or we want to ensure the cursored item is in view
+pub fn ensureScroll(self: *ListView) void {
+    if (self.cursor <= self.scroll.top) {
+        self.scroll.top = @intCast(self.cursor);
+        self.scroll.offset = 0;
+    } else {
+        self.scroll.wants_cursor = true;
+    }
+}
+
+/// Inserts children until add_height is < 0
+fn insertChildren(
+    self: *ListView,
+    ctx: vxfw.DrawContext,
+    builder: Builder,
+    child_list: *std.ArrayList(vxfw.SubSurface),
+    add_height: i17,
+) Allocator.Error!void {
+    assert(self.scroll.top > 0);
+    self.scroll.top -= 1;
+    var upheight = add_height;
+    while (self.scroll.top >= 0) : (self.scroll.top -= 1) {
+        // Get the child
+        const child = builder.itemAtIdx(self.scroll.top, self.cursor) orelse break;
+
+        const child_offset: u16 = if (self.draw_cursor) 2 else 0;
+        const max_size = ctx.max.size();
+
+        // Set up constraints. We let the child be the entire height if it wants
+        const child_ctx = ctx.withConstraints(
+            .{ .width = max_size.width - child_offset, .height = 0 },
+            .{ .width = max_size.width - child_offset, .height = null },
+        );
+
+        // Draw the child
+        const surf = try child.draw(child_ctx);
+
+        // Accumulate the height. Traversing backward so do this before setting origin
+        upheight -= surf.size.height;
+
+        // Insert the child to the beginning of the list
+        try child_list.insert(0, .{
+            .origin = .{ .col = 2, .row = upheight },
+            .surface = surf,
+            .z_index = 0,
+        });
+
+        // Break if we went past the top edge, or are the top item
+        if (upheight <= 0 or self.scroll.top == 0) break;
+    }
+
+    // Our new offset is the "upheight"
+    self.scroll.offset = upheight;
+
+    // Reset origins if we overshot and put the top item too low
+    if (self.scroll.top == 0 and upheight > 0) {
+        self.scroll.offset = 0;
+        var row: i17 = 0;
+        for (child_list.items) |*child| {
+            child.origin.row = row;
+            row += child.surface.size.height;
+        }
+    }
+    // Our new offset is the "upheight"
+    self.scroll.offset = upheight;
+}
+
+fn totalHeight(list: *const std.ArrayList(vxfw.SubSurface)) usize {
+    var result: usize = 0;
+    for (list.items) |child| {
+        result += child.surface.size.height;
+    }
+    return result;
+}
+
+fn drawBuilder(self: *ListView, ctx: vxfw.DrawContext, builder: Builder) Allocator.Error!vxfw.Surface {
+    defer self.scroll.wants_cursor = false;
+
+    // Get the size. asserts neither constraint is null
+    const max_size = ctx.max.size();
+    // Set up surface.
+    var surface: vxfw.Surface = .{
+        .size = max_size,
+        .widget = self.widget(),
+        .buffer = &.{},
+        .children = &.{},
+    };
+
+    // Set state
+    {
+        surface.focusable = true;
+        surface.handles_mouse = true;
+        // Assume we have more. We only know we don't after drawing
+        self.scroll.has_more = true;
+    }
+
+    var child_list = std.ArrayList(vxfw.SubSurface).init(ctx.arena);
+
+    // Accumulated height tracks how much height we have drawn. It's initial state is
+    // (scroll.offset + scroll.pending_lines) lines _above_ the surface top edge.
+    // Example:
+    // 1. Scroll up 3 lines:
+    //      pending_lines = -3
+    //      offset = 0
+    //      accumulated_height = -(0 + -3) = 3;
+    //      Our first widget is placed at row 3, we will need to fill this in after the draw
+    // 2. Scroll up 3 lines, with an offset of 4
+    //      pending_lines = -3
+    //      offset = 4
+    //      accumulated_height = -(4 + -3) = -1;
+    //      Our first widget is placed at row -1
+    // 3. Scroll down 3 lines:
+    //      pending_lines = 3
+    //      offset = 0
+    //      accumulated_height = -(0 + 3) = -3;
+    //      Our first widget is placed at row -3. It's possible it consumes the entire widget. We
+    //      will check for this at the end and only include visible children
+    var accumulated_height: i17 = -(self.scroll.offset + self.scroll.pending_lines);
+
+    // We handled the pending scroll by assigning accumulated_height. Reset it's state
+    self.scroll.pending_lines = 0;
+
+    // Set the initial index for our downard loop. We do this here because we might modify
+    // scroll.top before we traverse downward
+    var i: usize = self.scroll.top;
+
+    // If we are on the first item, and we have an upward scroll that consumed our offset, eg
+    // accumulated_height > 0, we reset state here. We can't scroll up anymore so we set
+    // accumulated_height to 0.
+    if (accumulated_height > 0 and self.scroll.top == 0) {
+        self.scroll.offset = 0;
+        accumulated_height = 0;
+    }
+
+    // If we are offset downward, insert widgets to the front of the list before traversing downard
+    if (accumulated_height > 0) {
+        try self.insertChildren(ctx, builder, &child_list, accumulated_height);
+        const last_child = child_list.items[child_list.items.len - 1];
+        accumulated_height = last_child.origin.row + last_child.surface.size.height;
+    }
+
+    const child_offset: u16 = if (self.draw_cursor) 2 else 0;
+
+    while (builder.itemAtIdx(i, self.cursor)) |child| {
+        // Defer the increment
+        defer i += 1;
+
+        // Set up constraints. We let the child be the entire height if it wants
+        const child_ctx = ctx.withConstraints(
+            .{ .width = max_size.width - child_offset, .height = 0 },
+            .{ .width = max_size.width - child_offset, .height = null },
+        );
+
+        // Draw the child
+        var surf = try child.draw(child_ctx);
+        // We set the child to non-focusable so that we can manage where the keyevents go
+        surf.focusable = false;
+
+        // Add the child surface to our list. It's offset from parent is the accumulated height
+        try child_list.append(.{
+            .origin = .{ .col = child_offset, .row = accumulated_height },
+            .surface = surf,
+            .z_index = 0,
+        });
+
+        // Accumulate the height
+        accumulated_height += surf.size.height;
+
+        if (self.scroll.wants_cursor and i < self.cursor)
+            continue // continue if we want the cursor and haven't gotten there yet
+        else if (accumulated_height >= max_size.height)
+            break; // Break if we drew enough
+    } else {
+        // This branch runs if we ran out of items. Set our state accordingly
+        self.scroll.has_more = false;
+    }
+
+    var total_height: usize = totalHeight(&child_list);
+
+    // If we reached the bottom, don't have enough height to fill the screen, and have room to add
+    // more, then we add more until out of items or filled the space. This can happen on a resize
+    if (!self.scroll.has_more and total_height < max_size.height and self.scroll.top > 0) {
+        try self.insertChildren(ctx, builder, &child_list, @intCast(max_size.height - total_height));
+        // Set the new total height
+        total_height = totalHeight(&child_list);
+    }
+
+    if (self.draw_cursor and self.cursor >= self.scroll.top) blk: {
+        // The index of the cursored widget in our child_list
+        const cursored_idx: u32 = self.cursor - self.scroll.top;
+        // Nothing to draw if our cursor is below our viewport
+        if (cursored_idx >= child_list.items.len) break :blk;
+
+        const sub = try ctx.arena.alloc(vxfw.SubSurface, 1);
+        const child = child_list.items[cursored_idx];
+        sub[0] = .{
+            .origin = .{ .col = child_offset, .row = 0 },
+            .surface = child.surface,
+            .z_index = 0,
+        };
+        const cursor_surf = try vxfw.Surface.initWithChildren(
+            ctx.arena,
+            self.widget(),
+            .{ .width = child_offset, .height = child.surface.size.height },
+            sub,
+        );
+        for (0..cursor_surf.size.height) |row| {
+            cursor_surf.writeCell(0, @intCast(row), cursor_indicator);
+        }
+        child_list.items[cursored_idx] = .{
+            .origin = .{ .col = 0, .row = child.origin.row },
+            .surface = cursor_surf,
+            .z_index = 0,
+        };
+    }
+
+    // If we want the cursor, we check that the cursored widget is fully in view. If it is too
+    // large, we position it so that it is the top item with a 0 offset
+    if (self.scroll.wants_cursor) {
+        const cursored_idx: u32 = self.cursor - self.scroll.top;
+        const sub = child_list.items[cursored_idx];
+        // The bottom row of the cursored widget
+        const bottom = sub.origin.row + sub.surface.size.height;
+        if (bottom > max_size.height) {
+            // Adjust the origin by the difference
+            // anchor bottom
+            var origin: i17 = max_size.height;
+            var idx: usize = cursored_idx + 1;
+            while (idx > 0) : (idx -= 1) {
+                var child = child_list.items[idx - 1];
+                origin -= child.surface.size.height;
+                child.origin.row = origin;
+                child_list.items[idx - 1] = child;
+            }
+        } else if (sub.surface.size.height >= max_size.height) {
+            // TODO: handle when the child is larger than our height.
+            // We need to change the max constraint to be optional sizes so that we can support
+            // unbounded drawing in scrollable areas
+            self.scroll.top = self.cursor;
+            self.scroll.offset = 0;
+            child_list.deinit();
+            try child_list.append(.{
+                .origin = .{ .col = 0, .row = 0 },
+                .surface = sub.surface,
+                .z_index = 0,
+            });
+            total_height = sub.surface.size.height;
+        }
+    }
+
+    // If we reached the bottom, we need to reset origins
+    if (!self.scroll.has_more and total_height < max_size.height) {
+        // anchor top
+        assert(self.scroll.top == 0);
+        self.scroll.offset = 0;
+        var origin: i17 = 0;
+        for (0..child_list.items.len) |idx| {
+            var child = child_list.items[idx];
+            child.origin.row = origin;
+            origin += child.surface.size.height;
+            child_list.items[idx] = child;
+        }
+    } else if (!self.scroll.has_more) {
+        // anchor bottom
+        var origin: i17 = max_size.height;
+        var idx: usize = child_list.items.len;
+        while (idx > 0) : (idx -= 1) {
+            var child = child_list.items[idx - 1];
+            origin -= child.surface.size.height;
+            child.origin.row = origin;
+            child_list.items[idx - 1] = child;
+        }
+    }
+
+    var start: usize = 0;
+    var end: usize = child_list.items.len;
+
+    for (child_list.items, 0..) |child, idx| {
+        if (child.origin.row <= 0 and child.origin.row + child.surface.size.height > 0) {
+            start = idx;
+            self.scroll.offset = -child.origin.row;
+            self.scroll.top += @intCast(idx);
+        }
+        if (child.origin.row > max_size.height) {
+            end = idx;
+            break;
+        }
+    }
+
+    surface.children = child_list.items[start..end];
+    return surface;
+}
+
+const SliceBuilder = struct {
+    slice: []const vxfw.Widget,
+
+    fn build(ptr: *const anyopaque, idx: usize, _: usize) ?vxfw.Widget {
+        const self: *const SliceBuilder = @ptrCast(@alignCast(ptr));
+        if (idx >= self.slice.len) return null;
+        return self.slice[idx];
+    }
+};
+
+test ListView {
+    // Create child widgets
+    const Text = @import("Text.zig");
+    const abc: Text = .{ .text = "abc\n  def\n  ghi" };
+    const def: Text = .{ .text = "def" };
+    const ghi: Text = .{ .text = "ghi" };
+    const jklmno: Text = .{ .text = "jkl\n mno" };
+    // 0 |*abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 | def
+    // 4   ghi
+    // 5   jkl
+    // 6     mno
+
+    // Create the list view
+    const list_view: ListView = .{
+        .wheel_scroll = 1, // Set wheel scroll to one
+        .children = .{ .slice = &.{
+            abc.widget(),
+            def.widget(),
+            ghi.widget(),
+            jklmno.widget(),
+        } },
+    };
+
+    // Boiler plate draw context
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    const list_widget = list_view.widget();
+    const draw_ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 16, .height = 4 },
+    };
+
+    var surface = try list_widget.draw(draw_ctx);
+    // ListView expands to max height and max width
+    try std.testing.expectEqual(4, surface.size.height);
+    try std.testing.expectEqual(16, surface.size.width);
+    // We have 2 children, because only visible children appear as a surface
+    try std.testing.expectEqual(2, surface.children.len);
+
+    var mouse_event: vaxis.Mouse = .{
+        .col = 0,
+        .row = 0,
+        .button = .wheel_up,
+        .mods = .{},
+        .type = .press,
+    };
+    // Event handlers need a context
+    var ctx: vxfw.EventContext = .{
+        .cmds = std.ArrayList(vxfw.Command).init(std.testing.allocator),
+    };
+    defer ctx.cmds.deinit();
+
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    // Wheel up doesn't adjust the scroll
+    try std.testing.expectEqual(0, list_view.scroll.top);
+    try std.testing.expectEqual(0, list_view.scroll.offset);
+
+    // Send a wheel down
+    mouse_event.button = .wheel_down;
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    // We have to draw the widget for scrolls to take effect
+    surface = try list_widget.draw(draw_ctx);
+    // 0  *abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 | def
+    // 4 | ghi
+    // 5   jkl
+    // 6     mno
+    // We should have gone down 1 line, and not changed our top widget
+    try std.testing.expectEqual(0, list_view.scroll.top);
+    try std.testing.expectEqual(1, list_view.scroll.offset);
+    // One more widget has scrolled into view
+    try std.testing.expectEqual(3, surface.children.len);
+
+    // Scroll down two more lines
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    surface = try list_widget.draw(draw_ctx);
+    // 0  *abc
+    // 1     def
+    // 2     ghi
+    // 3 | def
+    // 4 | ghi
+    // 5 | jkl
+    // 6 |   mno
+    // We should have gone down 2 lines, which scrolls our top widget out of view
+    try std.testing.expectEqual(1, list_view.scroll.top);
+    try std.testing.expectEqual(0, list_view.scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+
+    // Scroll down again. We shouldn't advance anymore since we are at the bottom
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    surface = try list_widget.draw(draw_ctx);
+    try std.testing.expectEqual(1, list_view.scroll.top);
+    try std.testing.expectEqual(0, list_view.scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+
+    // Mouse wheel events don't change the cursor position. Let's press "escape" to reset the
+    // viewport and bring our cursor into view
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.escape } });
+    surface = try list_widget.draw(draw_ctx);
+    try std.testing.expectEqual(0, list_view.scroll.top);
+    try std.testing.expectEqual(0, list_view.scroll.offset);
+    try std.testing.expectEqual(2, surface.children.len);
+
+    // Cursor down
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    surface = try list_widget.draw(draw_ctx);
+    // 0 | abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 |*def
+    // 4   ghi
+    // 5   jkl
+    // 6     mno
+    // Scroll doesn't change
+    try std.testing.expectEqual(0, list_view.scroll.top);
+    try std.testing.expectEqual(0, list_view.scroll.offset);
+    try std.testing.expectEqual(2, surface.children.len);
+    try std.testing.expectEqual(1, list_view.cursor);
+
+    // Cursor down
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    surface = try list_widget.draw(draw_ctx);
+    // 0   abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 | def
+    // 4 |*ghi
+    // 5   jkl
+    // 6     mno
+    // Scroll advances one row
+    try std.testing.expectEqual(0, list_view.scroll.top);
+    try std.testing.expectEqual(1, list_view.scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+    try std.testing.expectEqual(2, list_view.cursor);
+
+    // Cursor down
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    surface = try list_widget.draw(draw_ctx);
+    // 0   abc
+    // 1     def
+    // 2     ghi
+    // 3 | def
+    // 4 | ghi
+    // 5 |*jkl
+    // 6 |   mno
+    // We are cursored onto the last item. The entire last item comes into view, effectively
+    // advancing the scroll by 2
+    try std.testing.expectEqual(1, list_view.scroll.top);
+    try std.testing.expectEqual(0, list_view.scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+    try std.testing.expectEqual(3, list_view.cursor);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/ListView.zig
+++ b/src/vxfw/ListView.zig
@@ -257,7 +257,7 @@ fn insertChildren(
 
         // Insert the child to the beginning of the list
         try child_list.insert(0, .{
-            .origin = .{ .col = 2, .row = upheight },
+            .origin = .{ .col = if (self.draw_cursor) 2 else 0, .row = upheight },
             .surface = surf,
             .z_index = 0,
         });

--- a/src/vxfw/Padding.zig
+++ b/src/vxfw/Padding.zig
@@ -1,0 +1,148 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const Padding = @This();
+const PadValues = struct {
+    left: u16 = 0,
+    right: u16 = 0,
+    top: u16 = 0,
+    bottom: u16 = 0,
+};
+
+child: vxfw.Widget,
+padding: PadValues = .{},
+
+/// Vertical padding will be divided by 2 to approximate equal padding
+pub fn all(padding: u16) PadValues {
+    return .{
+        .left = padding,
+        .right = padding,
+        .top = padding / 2,
+        .bottom = padding / 2,
+    };
+}
+
+pub fn horizontal(padding: u16) PadValues {
+    return .{
+        .left = padding,
+        .right = padding,
+    };
+}
+
+pub fn vertical(padding: u16) PadValues {
+    return .{
+        .top = padding,
+        .bottom = padding,
+    };
+}
+
+pub fn widget(self: *const Padding) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *const Padding = @ptrCast(@alignCast(ptr));
+    return self.child.handleEvent(ctx, event);
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *const Padding = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *const Padding, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const pad = self.padding;
+    if (pad.left > 0 or pad.right > 0)
+        std.debug.assert(ctx.max.width != null);
+    if (pad.top > 0 or pad.bottom > 0)
+        std.debug.assert(ctx.max.height != null);
+    const inner_min: vxfw.Size = .{
+        .width = ctx.min.width -| (pad.right + pad.left),
+        .height = ctx.min.height -| (pad.top + pad.bottom),
+    };
+
+    const max_width: ?u16 = if (ctx.max.width) |max|
+        max -| (pad.right + pad.left)
+    else
+        null;
+    const max_height: ?u16 = if (ctx.max.height) |max|
+        max -| (pad.top + pad.bottom)
+    else
+        null;
+
+    const inner_max: vxfw.MaxSize = .{
+        .width = max_width,
+        .height = max_height,
+    };
+
+    const child_surface = try self.child.draw(ctx.withConstraints(inner_min, inner_max));
+
+    const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+    children[0] = .{
+        .surface = child_surface,
+        .z_index = 0,
+        .origin = .{ .row = pad.top, .col = pad.left },
+    };
+
+    const size = .{
+        .width = child_surface.size.width + (pad.right + pad.left),
+        .height = child_surface.size.height + (pad.top + pad.bottom),
+    };
+
+    // Create the padding surface
+    return .{
+        .size = size,
+        .widget = self.widget(),
+        .buffer = &.{},
+        .children = children,
+    };
+}
+
+test Padding {
+    const Text = @import("Text.zig");
+    // Will be height=1, width=3
+    const text: Text = .{ .text = "abc" };
+
+    const padding: Padding = .{
+        .child = text.widget(),
+        .padding = horizontal(1),
+    };
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    // Center expands to the max size. It must therefore have non-null max width and max height.
+    // These values are asserted in draw
+    const ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 10, .height = 10 },
+    };
+
+    const pad_widget = padding.widget();
+
+    const surface = try pad_widget.draw(ctx);
+    // Padding does not produce any drawable cells
+    try std.testing.expectEqual(0, surface.buffer.len);
+    // Padding has 1 child
+    try std.testing.expectEqual(1, surface.children.len);
+    const child = surface.children[0];
+    // Padding is the child size + padding
+    try std.testing.expectEqual(child.surface.size.width + 2, surface.size.width);
+    try std.testing.expectEqual(0, child.origin.row);
+    try std.testing.expectEqual(1, child.origin.col);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/RichText.zig
+++ b/src/vxfw/RichText.zig
@@ -83,6 +83,7 @@ pub fn draw(self: *const RichText, ctx: vxfw.DrawContext) Allocator.Error!vxfw.S
                 {
                     surface.writeCell(col, row, .{
                         .char = .{ .grapheme = "…", .width = 1 },
+                        .style = cell.style,
                     });
                     col = container_size.width;
                     continue;

--- a/src/vxfw/RichText.zig
+++ b/src/vxfw/RichText.zig
@@ -1,0 +1,374 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const vxfw = @import("vxfw.zig");
+
+const Allocator = std.mem.Allocator;
+
+const RichText = @This();
+
+pub const TextSpan = struct {
+    text: []const u8,
+    style: vaxis.Style = .{},
+};
+
+text: []const TextSpan,
+text_align: enum { left, center, right } = .left,
+base_style: vaxis.Style = .{},
+softwrap: bool = true,
+overflow: enum { ellipsis, clip } = .ellipsis,
+width_basis: enum { parent, longest_line } = .longest_line,
+
+pub fn widget(self: *const RichText) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = vxfw.noopEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *const RichText = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *const RichText, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    var iter = try SoftwrapIterator.init(self.text, ctx);
+    const container_size = self.findContainerSize(&iter);
+
+    // Create a surface of target width and max height. We'll trim the result after drawing
+    const surface = try vxfw.Surface.init(
+        ctx.arena,
+        self.widget(),
+        container_size,
+    );
+    const base: vaxis.Cell = .{ .style = self.base_style };
+    @memset(surface.buffer, base);
+
+    var row: u16 = 0;
+    if (self.softwrap) {
+        while (iter.next()) |line| {
+            if (ctx.max.outsideHeight(row)) break;
+            defer row += 1;
+            var col: u16 = switch (self.text_align) {
+                .left => 0,
+                .center => (container_size.width - line.width) / 2,
+                .right => container_size.width - line.width,
+            };
+            for (line.cells) |cell| {
+                surface.writeCell(col, row, cell);
+                col += cell.char.width;
+            }
+        }
+    } else {
+        while (iter.nextHardBreak()) |line| {
+            if (ctx.max.outsideHeight(row)) break;
+            const line_width = blk: {
+                var w: u16 = 0;
+                for (line) |cell| {
+                    w +|= cell.char.width;
+                }
+                break :blk w;
+            };
+            defer row += 1;
+            var col: u16 = switch (self.text_align) {
+                .left => 0,
+                .center => (container_size.width -| line_width) / 2,
+                .right => container_size.width -| line_width,
+            };
+            for (line) |cell| {
+                if (col + cell.char.width >= container_size.width and
+                    line_width > container_size.width and
+                    self.overflow == .ellipsis)
+                {
+                    surface.writeCell(col, row, .{
+                        .char = .{ .grapheme = "…", .width = 1 },
+                    });
+                    col = container_size.width;
+                    continue;
+                } else {
+                    surface.writeCell(col, row, cell);
+                    col += @intCast(cell.char.width);
+                }
+            }
+        }
+    }
+    return surface.trimHeight(@max(row, ctx.min.height));
+}
+
+/// Finds the widest line within the viewable portion of ctx
+fn findContainerSize(self: RichText, iter: *SoftwrapIterator) vxfw.Size {
+    defer iter.reset();
+    var row: u16 = 0;
+    var max_width: u16 = iter.ctx.min.width;
+    if (self.softwrap) {
+        while (iter.next()) |line| {
+            if (iter.ctx.max.outsideHeight(row)) break;
+            defer row += 1;
+            max_width = @max(max_width, line.width);
+        }
+    } else {
+        while (iter.nextHardBreak()) |line| {
+            if (iter.ctx.max.outsideHeight(row)) break;
+            defer row += 1;
+            var w: u16 = 0;
+            for (line) |cell| {
+                w +|= cell.char.width;
+            }
+            max_width = @max(max_width, w);
+        }
+    }
+    const result_width = switch (self.width_basis) {
+        .longest_line => blk: {
+            if (iter.ctx.max.width) |max|
+                break :blk @min(max, max_width)
+            else
+                break :blk max_width;
+        },
+        .parent => blk: {
+            std.debug.assert(iter.ctx.max.width != null);
+            break :blk iter.ctx.max.width.?;
+        },
+    };
+    return .{ .width = result_width, .height = @max(row, iter.ctx.min.height) };
+}
+
+pub const SoftwrapIterator = struct {
+    arena: std.heap.ArenaAllocator,
+    ctx: vxfw.DrawContext,
+    text: []const vaxis.Cell,
+    line: []const vaxis.Cell,
+    index: usize = 0,
+    // Index of the hard iterator
+    hard_index: usize = 0,
+
+    const soft_breaks = " \t";
+
+    pub const Line = struct {
+        width: u16,
+        cells: []const vaxis.Cell,
+    };
+
+    fn init(spans: []const TextSpan, ctx: vxfw.DrawContext) Allocator.Error!SoftwrapIterator {
+        // Estimate the number of cells we need
+        var len: usize = 0;
+        for (spans) |span| {
+            len += span.text.len;
+        }
+        var arena = std.heap.ArenaAllocator.init(ctx.arena);
+        var list = try std.ArrayList(vaxis.Cell).initCapacity(arena.allocator(), len);
+
+        for (spans) |span| {
+            var iter = ctx.graphemeIterator(span.text);
+            while (iter.next()) |grapheme| {
+                const char = grapheme.bytes(span.text);
+                const width = ctx.stringWidth(char);
+                const cell: vaxis.Cell = .{
+                    .char = .{ .grapheme = char, .width = @intCast(width) },
+                    .style = span.style,
+                };
+                try list.append(cell);
+            }
+        }
+        return .{
+            .arena = arena,
+            .ctx = ctx,
+            .text = list.items,
+            .line = &.{},
+        };
+    }
+
+    fn reset(self: *SoftwrapIterator) void {
+        self.index = 0;
+        self.hard_index = 0;
+        self.line = &.{};
+    }
+
+    fn deinit(self: *SoftwrapIterator) void {
+        self.arena.deinit();
+    }
+
+    fn nextHardBreak(self: *SoftwrapIterator) ?[]const vaxis.Cell {
+        if (self.hard_index >= self.text.len) return null;
+        const start = self.hard_index;
+        var saw_cr: bool = false;
+        while (self.hard_index < self.text.len) : (self.hard_index += 1) {
+            const cell = self.text[self.hard_index];
+            if (std.mem.eql(u8, cell.char.grapheme, "\r")) {
+                saw_cr = true;
+            }
+            if (std.mem.eql(u8, cell.char.grapheme, "\n")) {
+                self.hard_index += 1;
+                if (saw_cr) {
+                    return self.text[start .. self.hard_index - 2];
+                }
+                return self.text[start .. self.hard_index - 1];
+            }
+            if (saw_cr) {
+                // back up one
+                self.hard_index -= 1;
+                return self.text[start .. self.hard_index - 1];
+            }
+        } else return self.text[start..];
+    }
+
+    fn trimWSPRight(text: []const vaxis.Cell) []const vaxis.Cell {
+        // trim linear whitespace
+        var i: usize = text.len;
+        while (i > 0) : (i -= 1) {
+            if (std.mem.eql(u8, text[i - 1].char.grapheme, " ") or
+                std.mem.eql(u8, text[i - 1].char.grapheme, "\t"))
+            {
+                continue;
+            }
+            break;
+        }
+        return text[0..i];
+    }
+
+    fn trimWSPLeft(text: []const vaxis.Cell) []const vaxis.Cell {
+        // trim linear whitespace
+        var i: usize = 0;
+        while (i < text.len) : (i += 1) {
+            if (std.mem.eql(u8, text[i].char.grapheme, " ") or
+                std.mem.eql(u8, text[i].char.grapheme, "\t"))
+            {
+                continue;
+            }
+            break;
+        }
+        return text[i..];
+    }
+
+    fn next(self: *SoftwrapIterator) ?Line {
+        // Advance the hard iterator
+        if (self.index == self.line.len) {
+            self.line = self.nextHardBreak() orelse return null;
+            // trim linear whitespace
+            self.line = trimWSPRight(self.line);
+            self.index = 0;
+        }
+
+        const max_width = self.ctx.max.width orelse {
+            var width: u16 = 0;
+            for (self.line) |cell| {
+                width += cell.char.width;
+            }
+            self.index = self.line.len;
+            return .{
+                .width = width,
+                .cells = self.line,
+            };
+        };
+
+        const start = self.index;
+        var cur_width: u16 = 0;
+        while (self.index < self.line.len) {
+            // Find the width from current position to next word break
+            const idx = self.nextWrap();
+            const word = self.line[self.index..idx];
+            const next_width = blk: {
+                var w: usize = 0;
+                for (word) |ch| {
+                    w += ch.char.width;
+                }
+                break :blk w;
+            };
+
+            if (cur_width + next_width > max_width) {
+                // Trim the word to see if it can fit on a line by itself
+                const trimmed = trimWSPLeft(word);
+                const trimmed_width = next_width - trimmed.len;
+                if (trimmed_width > max_width) {
+                    // Won't fit on line by itself, so fit as much on this line as we can
+                    for (word) |cell| {
+                        if (cur_width + cell.char.width > max_width) {
+                            const end = self.index;
+                            return .{ .width = cur_width, .cells = self.line[start..end] };
+                        }
+                        cur_width += @intCast(cell.char.width);
+                        self.index += 1;
+                    }
+                }
+                const end = self.index;
+                // We are softwrapping, advance index to the start of the next word. This is equal
+                // to the difference in our word length and trimmed word length
+                self.index += (word.len - trimmed.len);
+                return .{ .width = cur_width, .cells = self.line[start..end] };
+            }
+
+            self.index = idx;
+            cur_width += @intCast(next_width);
+        }
+        return .{ .width = cur_width, .cells = self.line[start..] };
+    }
+
+    fn nextWrap(self: *SoftwrapIterator) usize {
+        var i: usize = self.index;
+
+        // Find the first non-whitespace character
+        while (i < self.line.len) : (i += 1) {
+            if (std.mem.eql(u8, self.line[i].char.grapheme, " ") or
+                std.mem.eql(u8, self.line[i].char.grapheme, "\t"))
+            {
+                continue;
+            }
+            break;
+        }
+
+        // Now find the first whitespace
+        while (i < self.line.len) : (i += 1) {
+            if (std.mem.eql(u8, self.line[i].char.grapheme, " ") or
+                std.mem.eql(u8, self.line[i].char.grapheme, "\t"))
+            {
+                return i;
+            }
+            continue;
+        }
+
+        return self.line.len;
+    }
+};
+
+test RichText {
+    var rich_text: RichText = .{
+        .text = &.{
+            .{ .text = "Hello, " },
+            .{ .text = "World", .style = .{ .bold = true } },
+        },
+    };
+
+    const rich_widget = rich_text.widget();
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    // Center expands to the max size. It must therefore have non-null max width and max height.
+    // These values are asserted in draw
+    const ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 7, .height = 2 },
+    };
+
+    {
+        // RichText softwraps by default
+        const surface = try rich_widget.draw(ctx);
+        try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 6, .height = 2 }), surface.size);
+    }
+
+    {
+        rich_text.softwrap = false;
+        rich_text.overflow = .ellipsis;
+        const surface = try rich_widget.draw(ctx);
+        try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 7, .height = 1 }), surface.size);
+        // The last character will be an ellipsis
+        try std.testing.expectEqualStrings("…", surface.buffer[surface.buffer.len - 1].char.grapheme);
+    }
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/SizedBox.zig
+++ b/src/vxfw/SizedBox.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const SizedBox = @This();
+
+child: vxfw.Widget,
+size: vxfw.Size,
+
+pub fn widget(self: *const SizedBox) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *const SizedBox = @ptrCast(@alignCast(ptr));
+    return self.child.handleEvent(ctx, event);
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *const SizedBox = @ptrCast(@alignCast(ptr));
+    const max: vxfw.MaxSize = .{
+        .width = if (ctx.max.width) |max_w| @min(max_w, self.size.width) else self.size.width,
+        .height = if (ctx.max.height) |max_h| @min(max_h, self.size.height) else self.size.height,
+    };
+    const min: vxfw.Size = .{
+        .width = @max(ctx.min.width, max.width.?),
+        .height = @max(ctx.min.height, max.height.?),
+    };
+    return self.child.draw(ctx.withConstraints(min, max));
+}
+
+test SizedBox {
+    // Create a test widget that saves the constraints it was given
+    const TestWidget = struct {
+        min: vxfw.Size,
+        max: vxfw.MaxSize,
+
+        pub fn widget(self: *@This()) vxfw.Widget {
+            return .{
+                .userdata = self,
+                .eventHandler = vxfw.noopEventHandler,
+                .drawFn = @This().typeErasedDrawFn,
+            };
+        }
+
+        fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+            const self: *@This() = @ptrCast(@alignCast(ptr));
+            self.min = ctx.min;
+            self.max = ctx.max;
+            return .{
+                .size = ctx.min,
+                .widget = self.widget(),
+                .buffer = &.{},
+                .children = &.{},
+            };
+        }
+    };
+
+    // Boiler plate draw context
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    var draw_ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 16, .height = 16 },
+    };
+
+    var test_widget: TestWidget = .{ .min = .{}, .max = .{} };
+
+    // SizedBox tries to draw the child widget at the specified size. It will shrink to fit within
+    // constraints
+    const sized_box: SizedBox = .{
+        .child = test_widget.widget(),
+        .size = .{ .width = 10, .height = 10 },
+    };
+
+    const box_widget = sized_box.widget();
+    _ = try box_widget.draw(draw_ctx);
+
+    // The sized box is smaller than the constraints, so we should be the desired size
+    try std.testing.expectEqual(sized_box.size, test_widget.min);
+    try std.testing.expectEqual(sized_box.size, test_widget.max.size());
+
+    draw_ctx.max.height = 8;
+    _ = try box_widget.draw(draw_ctx);
+    // The sized box is smaller than the constraints, so we should be that size
+    try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 10, .height = 8 }), test_widget.min);
+    try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 10, .height = 8 }), test_widget.max.size());
+
+    draw_ctx.max.width = 8;
+    _ = try box_widget.draw(draw_ctx);
+    // The sized box is smaller than the constraints, so we should be that size
+    try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 8, .height = 8 }), test_widget.min);
+    try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 8, .height = 8 }), test_widget.max.size());
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/Spinner.zig
+++ b/src/vxfw/Spinner.zig
@@ -1,0 +1,136 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const vxfw = @import("vxfw.zig");
+
+const Allocator = std.mem.Allocator;
+
+const Spinner = @This();
+
+const frames: []const []const u8 = &.{ "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
+const time_lapse: u32 = std.time.ms_per_s / 12; // 12 fps
+
+count: std.atomic.Value(u16) = .{ .raw = 0 },
+style: vaxis.Style = .{},
+/// The frame index
+frame: u4 = 0,
+
+/// Start, or add one, to the spinner counter. Thread safe.
+pub fn start(self: *Spinner) ?vxfw.Command {
+    const count = self.count.fetchAdd(1, .monotonic);
+    if (count == 0) {
+        return vxfw.Tick.in(time_lapse, self.widget());
+    }
+    return null;
+}
+
+/// Reduce one from the spinner counter. The spinner will stop when it reaches 0. Thread safe
+pub fn stop(self: *Spinner) void {
+    self.count.store(self.count.load(.unordered) -| 1, .unordered);
+}
+
+pub fn widget(self: *Spinner) vxfw.Widget {
+    return .{
+        .userdata = self,
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *Spinner = @ptrCast(@alignCast(ptr));
+    return self.handleEvent(ctx, event);
+}
+
+pub fn handleEvent(self: *Spinner, ctx: *vxfw.EventContext, event: vxfw.Event) Allocator.Error!void {
+    switch (event) {
+        .tick => {
+            const count = self.count.load(.unordered);
+
+            if (count == 0) return;
+            // Update frame
+            self.frame += 1;
+            if (self.frame >= frames.len) self.frame = 0;
+
+            // Update rearm
+            try ctx.tick(time_lapse, self.widget());
+        },
+        else => {},
+    }
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *Spinner = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *Spinner, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const size: vxfw.Size = .{
+        .width = @max(1, ctx.min.width),
+        .height = @max(1, ctx.min.height),
+    };
+
+    const surface = try vxfw.Surface.init(ctx.arena, self.widget(), size);
+    @memset(surface.buffer, .{ .style = self.style });
+
+    if (self.count.load(.unordered) == 0) return surface;
+
+    surface.writeCell(0, 0, .{
+        .char = .{
+            .grapheme = frames[self.frame],
+            .width = 1,
+        },
+        .style = self.style,
+    });
+    return surface;
+}
+
+test Spinner {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    // Create a spinner
+    var spinner: Spinner = .{};
+    // Get our widget interface
+    const spinner_widget = spinner.widget();
+
+    // Start the spinner. This (maybe) returns a Tick command to schedule the next frame. If the
+    // spinner is already running, no command is returned. Calling start is thread safe. The
+    // returned command can be added to an EventContext to schedule the frame
+    const maybe_cmd = spinner.start();
+    try std.testing.expect(maybe_cmd != null);
+    try std.testing.expect(maybe_cmd.? == .tick);
+    try std.testing.expectEqual(1, spinner.count.load(.unordered));
+
+    // If we call start again, we won't get another command but our counter will go up
+    const maybe_cmd2 = spinner.start();
+    try std.testing.expect(maybe_cmd2 == null);
+    try std.testing.expectEqual(2, spinner.count.load(.unordered));
+
+    // We are about to deliver the tick to the widget. We need an EventContext (the engine will
+    // provide this)
+    var ctx: vxfw.EventContext = .{ .cmds = vxfw.CommandList.init(arena.allocator()) };
+
+    // The event loop handles the tick event and calls us back with a .tick event. If we should keep
+    // running, we will add a new tick event
+    try spinner_widget.handleEvent(&ctx, .tick);
+
+    // Receiving a .tick advances the frame
+    try std.testing.expectEqual(1, spinner.frame);
+
+    // Simulate a draw
+    const surface = try spinner_widget.draw(.{ .arena = arena.allocator(), .min = .{}, .max = .{} });
+
+    // Spinner will try to be 1x1
+    try std.testing.expectEqual(1, surface.size.width);
+    try std.testing.expectEqual(1, surface.size.height);
+
+    // Stopping the spinner decrements our counter
+    spinner.stop();
+    try std.testing.expectEqual(1, spinner.count.load(.unordered));
+    spinner.stop();
+    try std.testing.expectEqual(0, spinner.count.load(.unordered));
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/SplitView.zig
+++ b/src/vxfw/SplitView.zig
@@ -1,0 +1,198 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const SplitView = @This();
+
+lhs: vxfw.Widget,
+rhs: vxfw.Widget,
+constrain: enum { lhs, rhs } = .lhs,
+style: vaxis.Style = .{},
+/// min width for the constrained side
+min_width: u16 = 0,
+/// max width for the constrained side
+max_width: ?u16 = null,
+/// Target width to draw at
+width: u16,
+
+/// Statically allocated children
+children: [2]vxfw.SubSurface = undefined,
+
+// State
+pressed: bool = false,
+mouse_set: bool = false,
+
+pub fn widget(self: *const SplitView) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *SplitView = @ptrCast(@alignCast(ptr));
+    if (event != .mouse) return;
+    const mouse = event.mouse;
+
+    const separator_col: u16 = switch (self.constrain) {
+        .lhs => self.width + 1,
+        .rhs => self.width -| 1,
+    };
+
+    // If we are on the separator, we always set the mouse shape
+    if (mouse.col == separator_col) {
+        try ctx.setMouseShape(.@"ew-resize");
+        self.mouse_set = true;
+        // Set pressed state if we are a left click
+        if (mouse.type == .press and mouse.button == .left) {
+            self.pressed = true;
+        }
+    } else if (self.mouse_set) {
+        // If we have set the mouse state and *aren't* over the separator, default the mouse state
+        try ctx.setMouseShape(.default);
+        self.mouse_set = false;
+    }
+
+    // On release, we reset state
+    if (mouse.type == .release) {
+        self.pressed = false;
+        self.mouse_set = false;
+        try ctx.setMouseShape(.default);
+    }
+
+    // If pressed, we always keep the mouse shape and we update the width
+    if (self.pressed) {
+        try ctx.setMouseShape(.@"ew-resize");
+        self.width = @max(self.min_width, mouse.col -| 1);
+        if (self.max_width) |max| {
+            self.width = @min(self.width, max);
+        }
+    }
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *SplitView = @ptrCast(@alignCast(ptr));
+    // Fills entire space
+    const max = ctx.max.size();
+    // Constrain width to the max
+    self.width = @min(self.width, max.width);
+
+    // The constrained side is equal to the width
+    const constrained_min: vxfw.Size = .{ .width = self.width, .height = max.height };
+    const constrained_max: vxfw.MaxSize = .{ .width = self.width, .height = max.height };
+
+    const unconstrained_min: vxfw.Size = .{ .width = max.width - self.width - 2, .height = max.height };
+    const unconstrained_max: vxfw.MaxSize = .{ .width = max.width - self.width - 2, .height = max.height };
+
+    switch (self.constrain) {
+        .lhs => {
+            const lhs_ctx = ctx.withConstraints(constrained_min, constrained_max);
+            const lhs_surface = try self.lhs.draw(lhs_ctx);
+
+            self.children[0] = .{
+                .surface = lhs_surface,
+                .origin = .{ .row = 0, .col = 0 },
+            };
+            const rhs_ctx = ctx.withConstraints(unconstrained_min, unconstrained_max);
+            const rhs_surface = try self.rhs.draw(rhs_ctx);
+            self.children[1] = .{
+                .surface = rhs_surface,
+                .origin = .{ .row = 0, .col = self.width + 2 },
+            };
+        },
+        .rhs => {
+            const lhs_ctx = ctx.withConstraints(unconstrained_min, unconstrained_max);
+            const lhs_surface = try self.lhs.draw(lhs_ctx);
+            self.children[0] = .{
+                .surface = lhs_surface,
+                .origin = .{ .row = 0, .col = 0 },
+            };
+            const rhs_ctx = ctx.withConstraints(constrained_min, constrained_max);
+            const rhs_surface = try self.rhs.draw(rhs_ctx);
+            self.children[1] = .{
+                .surface = rhs_surface,
+                .origin = .{ .row = 0, .col = self.width + 2 },
+            };
+        },
+    }
+
+    var surface = try vxfw.Surface.initWithChildren(ctx.arena, self.widget(), max, &self.children);
+    surface.handles_mouse = true;
+    for (0..max.height) |row| {
+        surface.writeCell(self.width + 1, @intCast(row), .{
+            .char = .{ .grapheme = "│", .width = 1 },
+            .style = self.style,
+        });
+    }
+    return surface;
+}
+
+test SplitView {
+    // Boiler plate draw context
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    const draw_ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 16, .height = 16 },
+    };
+
+    // Create LHS and RHS widgets
+    const lhs: vxfw.Text = .{ .text = "Left hand side" };
+    const rhs: vxfw.Text = .{ .text = "Right hand side" };
+
+    var split_view: SplitView = .{
+        .lhs = lhs.widget(),
+        .rhs = rhs.widget(),
+        .width = 8,
+    };
+
+    const split_widget = split_view.widget();
+    {
+        const surface = try split_widget.draw(draw_ctx);
+        // SplitView expands to fill the space
+        try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 16, .height = 16 }), surface.size);
+        // It has two children
+        try std.testing.expectEqual(2, surface.children.len);
+        // The left child should have a width = SplitView.width
+        try std.testing.expectEqual(split_view.width, surface.children[0].surface.size.width);
+    }
+
+    // Send the widget a mouse press on the separator
+    var mouse: vaxis.Mouse = .{
+        // The separator is width + 1
+        .col = split_view.width + 1,
+        .row = 0,
+        .type = .press,
+        .button = .left,
+        .mods = .{},
+    };
+
+    var ctx: vxfw.EventContext = .{
+        .cmds = std.ArrayList(vxfw.Command).init(arena.allocator()),
+    };
+    try split_widget.handleEvent(&ctx, .{ .mouse = mouse });
+    // We should get a command to change the mouse shape
+    try std.testing.expect(ctx.cmds.items[0] == .set_mouse_shape);
+    try std.testing.expect(ctx.redraw);
+    try std.testing.expect(split_view.pressed);
+
+    // If we move the mouse, we should update the width
+    mouse.col = 2;
+    mouse.type = .drag;
+    try split_widget.handleEvent(&ctx, .{ .mouse = mouse });
+    try std.testing.expect(ctx.redraw);
+    try std.testing.expect(split_view.pressed);
+    try std.testing.expectEqual(mouse.col - 1, split_view.width);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/SplitView.zig
+++ b/src/vxfw/SplitView.zig
@@ -35,7 +35,14 @@ pub fn widget(self: *const SplitView) vxfw.Widget {
 
 fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
     const self: *SplitView = @ptrCast(@alignCast(ptr));
-    if (event != .mouse) return;
+    switch (event) {
+        .mouse_leave => {
+            self.pressed = false;
+            return;
+        },
+        .mouse => {},
+        else => return,
+    }
     const mouse = event.mouse;
 
     const separator_col: u16 = switch (self.constrain) {
@@ -71,6 +78,7 @@ fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.
         if (self.max_width) |max| {
             self.width = @min(self.width, max);
         }
+        ctx.consume_event = true;
     }
 }
 

--- a/src/vxfw/Text.zig
+++ b/src/vxfw/Text.zig
@@ -1,0 +1,494 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const Text = @This();
+
+text: []const u8,
+style: vaxis.Style = .{},
+text_align: enum { left, center, right } = .left,
+softwrap: bool = true,
+overflow: enum { ellipsis, clip } = .ellipsis,
+width_basis: enum { parent, longest_line } = .longest_line,
+
+pub fn widget(self: *const Text) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = vxfw.noopEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *const Text = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *const Text, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const container_size = self.findContainerSize(ctx);
+
+    // Create a surface of target width and max height. We'll trim the result after drawing
+    const surface = try vxfw.Surface.init(
+        ctx.arena,
+        self.widget(),
+        container_size,
+    );
+    const base_style: vaxis.Style = .{
+        .fg = self.style.fg,
+        .bg = self.style.bg,
+        .reverse = self.style.reverse,
+    };
+    const base: vaxis.Cell = .{ .style = base_style };
+    @memset(surface.buffer, base);
+
+    var row: u16 = 0;
+    if (self.softwrap) {
+        var iter = SoftwrapIterator.init(self.text, ctx);
+        while (iter.next()) |line| {
+            if (row >= container_size.height) break;
+            defer row += 1;
+            var col: u16 = switch (self.text_align) {
+                .left => 0,
+                .center => (container_size.width - line.width) / 2,
+                .right => container_size.width - line.width,
+            };
+            var char_iter = ctx.graphemeIterator(line.bytes);
+            while (char_iter.next()) |char| {
+                const grapheme = char.bytes(line.bytes);
+                const grapheme_width: u8 = @intCast(ctx.stringWidth(grapheme));
+                surface.writeCell(col, row, .{
+                    .char = .{ .grapheme = grapheme, .width = grapheme_width },
+                    .style = self.style,
+                });
+                col += grapheme_width;
+            }
+        }
+    } else {
+        var line_iter: LineIterator = .{ .buf = self.text };
+        while (line_iter.next()) |line| {
+            if (row >= container_size.height) break;
+            const line_width = ctx.stringWidth(line);
+            defer row += 1;
+            const resolved_line_width = @min(container_size.width, line_width);
+            var col: u16 = switch (self.text_align) {
+                .left => 0,
+                .center => (container_size.width - resolved_line_width) / 2,
+                .right => container_size.width - resolved_line_width,
+            };
+            var char_iter = ctx.graphemeIterator(line);
+            while (char_iter.next()) |char| {
+                if (col >= container_size.width) break;
+                const grapheme = char.bytes(line);
+                const grapheme_width: u8 = @intCast(ctx.stringWidth(grapheme));
+
+                if (col + grapheme_width >= container_size.width and
+                    line_width > container_size.width and
+                    self.overflow == .ellipsis)
+                {
+                    surface.writeCell(col, row, .{
+                        .char = .{ .grapheme = "…", .width = 1 },
+                        .style = self.style,
+                    });
+                    col = container_size.width;
+                } else {
+                    surface.writeCell(col, row, .{
+                        .char = .{ .grapheme = grapheme, .width = grapheme_width },
+                        .style = self.style,
+                    });
+                    col += @intCast(grapheme_width);
+                }
+            }
+        }
+    }
+    return surface.trimHeight(@max(row, ctx.min.height));
+}
+
+/// Determines the container size by finding the widest line in the viewable area
+fn findContainerSize(self: Text, ctx: vxfw.DrawContext) vxfw.Size {
+    var row: u16 = 0;
+    var max_width: u16 = ctx.min.width;
+    if (self.softwrap) {
+        var iter = SoftwrapIterator.init(self.text, ctx);
+        while (iter.next()) |line| {
+            if (ctx.max.outsideHeight(row))
+                break;
+
+            defer row += 1;
+            max_width = @max(max_width, line.width);
+        }
+    } else {
+        var line_iter: LineIterator = .{ .buf = self.text };
+        while (line_iter.next()) |line| {
+            if (ctx.max.outsideHeight(row))
+                break;
+            const line_width: u16 = @truncate(ctx.stringWidth(line));
+            defer row += 1;
+            const resolved_line_width = if (ctx.max.width) |max|
+                @min(max, line_width)
+            else
+                line_width;
+            max_width = @max(max_width, resolved_line_width);
+        }
+    }
+    const result_width = switch (self.width_basis) {
+        .longest_line => blk: {
+            if (ctx.max.width) |max|
+                break :blk @min(max, max_width)
+            else
+                break :blk max_width;
+        },
+        .parent => blk: {
+            std.debug.assert(ctx.max.width != null);
+            break :blk ctx.max.width.?;
+        },
+    };
+    return .{ .width = result_width, .height = @max(row, ctx.min.height) };
+}
+
+/// Iterates a slice of bytes by linebreaks. Lines are split by '\r', '\n', or '\r\n'
+pub const LineIterator = struct {
+    buf: []const u8,
+    index: usize = 0,
+
+    fn next(self: *LineIterator) ?[]const u8 {
+        if (self.index >= self.buf.len) return null;
+
+        const start = self.index;
+        const end = std.mem.indexOfAnyPos(u8, self.buf, self.index, "\r\n") orelse {
+            self.index = self.buf.len;
+            return self.buf[start..];
+        };
+
+        self.index = end;
+        self.consumeCR();
+        self.consumeLF();
+        return self.buf[start..end];
+    }
+
+    // consumes a \n byte
+    fn consumeLF(self: *LineIterator) void {
+        if (self.index >= self.buf.len) return;
+        if (self.buf[self.index] == '\n') self.index += 1;
+    }
+
+    // consumes a \r byte
+    fn consumeCR(self: *LineIterator) void {
+        if (self.index >= self.buf.len) return;
+        if (self.buf[self.index] == '\r') self.index += 1;
+    }
+};
+
+pub const SoftwrapIterator = struct {
+    ctx: vxfw.DrawContext,
+    line: []const u8 = "",
+    index: usize = 0,
+    hard_iter: LineIterator,
+
+    pub const Line = struct {
+        width: u16,
+        bytes: []const u8,
+    };
+
+    const soft_breaks = " \t";
+
+    fn init(buf: []const u8, ctx: vxfw.DrawContext) SoftwrapIterator {
+        return .{
+            .ctx = ctx,
+            .hard_iter = .{ .buf = buf },
+        };
+    }
+
+    fn next(self: *SoftwrapIterator) ?Line {
+        // Advance the hard iterator
+        if (self.index == self.line.len) {
+            self.line = self.hard_iter.next() orelse return null;
+            self.line = std.mem.trimRight(u8, self.line, " \t");
+            self.index = 0;
+        }
+
+        const start = self.index;
+        var cur_width: u16 = 0;
+        while (self.index < self.line.len) {
+            const idx = self.nextWrap();
+            const word = self.line[self.index..idx];
+            const next_width = self.ctx.stringWidth(word);
+
+            if (self.ctx.max.width) |max| {
+                if (cur_width + next_width > max) {
+                    // Trim the word to see if it can fit on a line by itself
+                    const trimmed = std.mem.trimLeft(u8, word, " \t");
+                    const trimmed_bytes = word.len - trimmed.len;
+                    // The number of bytes we trimmed is equal to the reduction in length
+                    const trimmed_width = next_width - trimmed_bytes;
+                    if (trimmed_width > max) {
+                        // Won't fit on line by itself, so fit as much on this line as we can
+                        var iter = self.ctx.graphemeIterator(word);
+                        while (iter.next()) |item| {
+                            const grapheme = item.bytes(word);
+                            const w = self.ctx.stringWidth(grapheme);
+                            if (cur_width + w > max) {
+                                const end = self.index;
+                                return .{ .width = cur_width, .bytes = self.line[start..end] };
+                            }
+                            cur_width += @intCast(w);
+                            self.index += grapheme.len;
+                        }
+                    }
+                    // We are softwrapping, advance index to the start of the next word
+                    const end = self.index;
+                    self.index = std.mem.indexOfNonePos(u8, self.line, self.index, soft_breaks) orelse self.line.len;
+                    return .{ .width = cur_width, .bytes = self.line[start..end] };
+                }
+            }
+
+            self.index = idx;
+            cur_width += @intCast(next_width);
+        }
+        return .{ .width = cur_width, .bytes = self.line[start..] };
+    }
+
+    /// Determines the index of the end of the next word
+    fn nextWrap(self: *SoftwrapIterator) usize {
+        // Find the first linear whitespace char
+        const start_pos = std.mem.indexOfNonePos(u8, self.line, self.index, soft_breaks) orelse
+            return self.line.len;
+        if (std.mem.indexOfAnyPos(u8, self.line, start_pos, soft_breaks)) |idx| {
+            return idx;
+        }
+        return self.line.len;
+    }
+
+    // consumes a \n byte
+    fn consumeLF(self: *SoftwrapIterator) void {
+        if (self.index >= self.buf.len) return;
+        if (self.buf[self.index] == '\n') self.index += 1;
+    }
+
+    // consumes a \r byte
+    fn consumeCR(self: *SoftwrapIterator) void {
+        if (self.index >= self.buf.len) return;
+        if (self.buf[self.index] == '\r') self.index += 1;
+    }
+};
+
+test "SoftwrapIterator: LF breaks" {
+    const unicode = try vaxis.Unicode.init(std.testing.allocator);
+    defer unicode.deinit();
+    vxfw.DrawContext.init(&unicode, .unicode);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const ctx: vxfw.DrawContext = .{
+        .min = .{ .width = 0, .height = 0 },
+        .max = .{ .width = 20, .height = 10 },
+        .arena = arena.allocator(),
+    };
+    var iter = SoftwrapIterator.init("Hello, \n world", ctx);
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("Hello,", first.?.bytes);
+    try std.testing.expectEqual(6, first.?.width);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings(" world", second.?.bytes);
+    try std.testing.expectEqual(6, second.?.width);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test "SoftwrapIterator: soft breaks that fit" {
+    const unicode = try vaxis.Unicode.init(std.testing.allocator);
+    defer unicode.deinit();
+    vxfw.DrawContext.init(&unicode, .unicode);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const ctx: vxfw.DrawContext = .{
+        .min = .{ .width = 0, .height = 0 },
+        .max = .{ .width = 6, .height = 10 },
+        .arena = arena.allocator(),
+    };
+    var iter = SoftwrapIterator.init("Hello, \nworld", ctx);
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("Hello,", first.?.bytes);
+    try std.testing.expectEqual(6, first.?.width);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings("world", second.?.bytes);
+    try std.testing.expectEqual(5, second.?.width);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test "SoftwrapIterator: soft breaks that are longer than width" {
+    const unicode = try vaxis.Unicode.init(std.testing.allocator);
+    defer unicode.deinit();
+    vxfw.DrawContext.init(&unicode, .unicode);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const ctx: vxfw.DrawContext = .{
+        .min = .{ .width = 0, .height = 0 },
+        .max = .{ .width = 6, .height = 10 },
+        .arena = arena.allocator(),
+    };
+    var iter = SoftwrapIterator.init("very-long-word \nworld", ctx);
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("very-l", first.?.bytes);
+    try std.testing.expectEqual(6, first.?.width);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings("ong-wo", second.?.bytes);
+    try std.testing.expectEqual(6, second.?.width);
+
+    const third = iter.next();
+    try std.testing.expect(third != null);
+    try std.testing.expectEqualStrings("rd", third.?.bytes);
+    try std.testing.expectEqual(2, third.?.width);
+
+    const fourth = iter.next();
+    try std.testing.expect(fourth != null);
+    try std.testing.expectEqualStrings("world", fourth.?.bytes);
+    try std.testing.expectEqual(5, fourth.?.width);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test "SoftwrapIterator: soft breaks with leading spaces" {
+    const unicode = try vaxis.Unicode.init(std.testing.allocator);
+    defer unicode.deinit();
+    vxfw.DrawContext.init(&unicode, .unicode);
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    const ctx: vxfw.DrawContext = .{
+        .min = .{ .width = 0, .height = 0 },
+        .max = .{ .width = 6, .height = 10 },
+        .arena = arena.allocator(),
+    };
+    var iter = SoftwrapIterator.init("Hello,        \n world", ctx);
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("Hello,", first.?.bytes);
+    try std.testing.expectEqual(6, first.?.width);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings(" world", second.?.bytes);
+    try std.testing.expectEqual(6, second.?.width);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test "LineIterator: LF breaks" {
+    const input = "Hello, \n world";
+    var iter: LineIterator = .{ .buf = input };
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("Hello, ", first.?);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings(" world", second.?);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test "LineIterator: CR breaks" {
+    const input = "Hello, \r world";
+    var iter: LineIterator = .{ .buf = input };
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("Hello, ", first.?);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings(" world", second.?);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test "LineIterator: CRLF breaks" {
+    const input = "Hello, \r\n world";
+    var iter: LineIterator = .{ .buf = input };
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("Hello, ", first.?);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings(" world", second.?);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test "LineIterator: CRLF breaks with empty line" {
+    const input = "Hello, \r\n\r\n world";
+    var iter: LineIterator = .{ .buf = input };
+    const first = iter.next();
+    try std.testing.expect(first != null);
+    try std.testing.expectEqualStrings("Hello, ", first.?);
+
+    const second = iter.next();
+    try std.testing.expect(second != null);
+    try std.testing.expectEqualStrings("", second.?);
+
+    const third = iter.next();
+    try std.testing.expect(third != null);
+    try std.testing.expectEqualStrings(" world", third.?);
+
+    const end = iter.next();
+    try std.testing.expect(end == null);
+}
+
+test Text {
+    var text: Text = .{ .text = "Hello, world" };
+    const text_widget = text.widget();
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    // Center expands to the max size. It must therefore have non-null max width and max height.
+    // These values are asserted in draw
+    const ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 7, .height = 2 },
+    };
+
+    {
+        // Text softwraps by default
+        const surface = try text_widget.draw(ctx);
+        try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 6, .height = 2 }), surface.size);
+    }
+
+    {
+        text.softwrap = false;
+        text.overflow = .ellipsis;
+        const surface = try text_widget.draw(ctx);
+        try std.testing.expectEqual(@as(vxfw.Size, .{ .width = 7, .height = 1 }), surface.size);
+        // The last character will be an ellipsis
+        try std.testing.expectEqualStrings("…", surface.buffer[surface.buffer.len - 1].char.grapheme);
+    }
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/TextField.zig
+++ b/src/vxfw/TextField.zig
@@ -1,0 +1,600 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const vxfw = @import("vxfw.zig");
+
+const assert = std.debug.assert;
+
+const Allocator = std.mem.Allocator;
+const Key = vaxis.Key;
+const Cell = vaxis.Cell;
+const Window = vaxis.Window;
+const Unicode = vaxis.Unicode;
+
+const TextField = @This();
+
+const ellipsis: Cell.Character = .{ .grapheme = "…", .width = 1 };
+
+// Index of our cursor
+buf: Buffer,
+
+/// the number of graphemes to skip when drawing. Used for horizontal scrolling
+draw_offset: u16 = 0,
+/// the column we placed the cursor the last time we drew
+prev_cursor_col: u16 = 0,
+/// the grapheme index of the cursor the last time we drew
+prev_cursor_idx: u16 = 0,
+/// approximate distance from an edge before we scroll
+scroll_offset: u4 = 4,
+/// Previous width we drew at
+prev_width: u16 = 0,
+
+unicode: *const Unicode,
+
+previous_val: []const u8 = "",
+
+userdata: ?*anyopaque = null,
+onChange: ?*const fn (?*anyopaque, *vxfw.EventContext, []const u8) anyerror!void = null,
+onSubmit: ?*const fn (?*anyopaque, *vxfw.EventContext, []const u8) anyerror!void = null,
+
+pub fn init(alloc: std.mem.Allocator, unicode: *const Unicode) TextField {
+    return TextField{
+        .buf = Buffer.init(alloc),
+        .unicode = unicode,
+    };
+}
+
+pub fn deinit(self: *TextField) void {
+    self.buf.allocator.free(self.previous_val);
+    self.buf.deinit();
+}
+
+pub fn widget(self: *TextField) vxfw.Widget {
+    return .{
+        .userdata = self,
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *TextField = @ptrCast(@alignCast(ptr));
+    return self.handleEvent(ctx, event);
+}
+
+pub fn handleEvent(self: *TextField, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    switch (event) {
+        .focus_out, .focus_in => ctx.redraw = true,
+        .key_press => |key| {
+            if (key.matches(Key.backspace, .{})) {
+                self.deleteBeforeCursor();
+                return self.checkChanged(ctx);
+            } else if (key.matches(Key.delete, .{}) or key.matches('d', .{ .ctrl = true })) {
+                self.deleteAfterCursor();
+                return self.checkChanged(ctx);
+            } else if (key.matches(Key.left, .{}) or key.matches('b', .{ .ctrl = true })) {
+                self.cursorLeft();
+                return ctx.consumeAndRedraw();
+            } else if (key.matches(Key.right, .{}) or key.matches('f', .{ .ctrl = true })) {
+                self.cursorRight();
+                return ctx.consumeAndRedraw();
+            } else if (key.matches('a', .{ .ctrl = true }) or key.matches(Key.home, .{})) {
+                self.buf.moveGapLeft(self.buf.firstHalf().len);
+                return ctx.consumeAndRedraw();
+            } else if (key.matches('e', .{ .ctrl = true }) or key.matches(Key.end, .{})) {
+                self.buf.moveGapRight(self.buf.secondHalf().len);
+                return ctx.consumeAndRedraw();
+            } else if (key.matches('k', .{ .ctrl = true })) {
+                self.deleteToEnd();
+                return self.checkChanged(ctx);
+            } else if (key.matches('u', .{ .ctrl = true })) {
+                self.deleteToStart();
+                return self.checkChanged(ctx);
+            } else if (key.matches('b', .{ .alt = true }) or key.matches(Key.left, .{ .alt = true })) {
+                self.moveBackwardWordwise();
+                return ctx.consumeAndRedraw();
+            } else if (key.matches('f', .{ .alt = true }) or key.matches(Key.right, .{ .alt = true })) {
+                self.moveForwardWordwise();
+                return ctx.consumeAndRedraw();
+            } else if (key.matches('w', .{ .ctrl = true }) or key.matches(Key.backspace, .{ .alt = true })) {
+                self.deleteWordBefore();
+                return self.checkChanged(ctx);
+            } else if (key.matches('d', .{ .alt = true })) {
+                self.deleteWordAfter();
+                return self.checkChanged(ctx);
+            } else if (key.matches(vaxis.Key.enter, .{})) {
+                if (self.onSubmit) |onSubmit| {
+                    try onSubmit(self.userdata, ctx, self.previous_val);
+                    return ctx.consumeAndRedraw();
+                }
+            } else if (key.text) |text| {
+                try self.insertSliceAtCursor(text);
+                return self.checkChanged(ctx);
+            }
+        },
+        else => {},
+    }
+}
+
+fn checkChanged(self: *TextField, ctx: *vxfw.EventContext) anyerror!void {
+    const new = try self.buf.dupe();
+    if (std.mem.eql(u8, new, self.previous_val)) {
+        self.buf.allocator.free(new);
+        return ctx.consumeAndRedraw();
+    }
+    self.buf.allocator.free(self.previous_val);
+    self.previous_val = new;
+    if (self.onChange) |onChange| {
+        try onChange(self.userdata, ctx, new);
+    }
+    ctx.consumeAndRedraw();
+}
+
+/// insert text at the cursor position
+pub fn insertSliceAtCursor(self: *TextField, data: []const u8) std.mem.Allocator.Error!void {
+    var iter = self.unicode.graphemeIterator(data);
+    while (iter.next()) |text| {
+        try self.buf.insertSliceAtCursor(text.bytes(data));
+    }
+}
+
+pub fn sliceToCursor(self: *TextField, buf: []u8) []const u8 {
+    assert(buf.len >= self.buf.cursor);
+    @memcpy(buf[0..self.buf.cursor], self.buf.firstHalf());
+    return buf[0..self.buf.cursor];
+}
+
+/// calculates the display width from the draw_offset to the cursor
+pub fn widthToCursor(self: *TextField, ctx: vxfw.DrawContext) u16 {
+    var width: u16 = 0;
+    const first_half = self.buf.firstHalf();
+    var first_iter = self.unicode.graphemeIterator(first_half);
+    var i: usize = 0;
+    while (first_iter.next()) |grapheme| {
+        defer i += 1;
+        if (i < self.draw_offset) {
+            continue;
+        }
+        const g = grapheme.bytes(first_half);
+        width += @intCast(ctx.stringWidth(g));
+    }
+    return width;
+}
+
+pub fn cursorLeft(self: *TextField) void {
+    // We need to find the size of the last grapheme in the first half
+    var iter = self.unicode.graphemeIterator(self.buf.firstHalf());
+    var len: usize = 0;
+    while (iter.next()) |grapheme| {
+        len = grapheme.len;
+    }
+    self.buf.moveGapLeft(len);
+}
+
+pub fn cursorRight(self: *TextField) void {
+    var iter = self.unicode.graphemeIterator(self.buf.secondHalf());
+    const grapheme = iter.next() orelse return;
+    self.buf.moveGapRight(grapheme.len);
+}
+
+pub fn graphemesBeforeCursor(self: *const TextField) u16 {
+    const first_half = self.buf.firstHalf();
+    var first_iter = self.unicode.graphemeIterator(first_half);
+    var i: u16 = 0;
+    while (first_iter.next()) |_| {
+        i += 1;
+    }
+    return i;
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *TextField = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn draw(self: *TextField, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    std.debug.assert(ctx.max.width != null);
+    const max_width = ctx.max.width.?;
+    if (max_width != self.prev_width) {
+        self.prev_width = max_width;
+        self.draw_offset = 0;
+        self.prev_cursor_col = 0;
+    }
+    // Create a surface with max width and a minimum height of 1.
+    var surface = try vxfw.Surface.init(
+        ctx.arena,
+        self.widget(),
+        .{ .width = max_width, .height = @max(ctx.min.height, 1) },
+    );
+    surface.focusable = true;
+    surface.handles_mouse = true;
+
+    const base: vaxis.Cell = .{ .style = .{} };
+    @memset(surface.buffer, base);
+    const style: vaxis.Style = .{};
+    const cursor_idx = self.graphemesBeforeCursor();
+    if (cursor_idx < self.draw_offset) self.draw_offset = cursor_idx;
+    if (max_width == 0) return surface;
+    while (true) {
+        const width = self.widthToCursor(ctx);
+        if (width >= max_width) {
+            self.draw_offset +|= width - max_width + 1;
+            continue;
+        } else break;
+    }
+
+    self.prev_cursor_idx = cursor_idx;
+    self.prev_cursor_col = 0;
+
+    const first_half = self.buf.firstHalf();
+    var first_iter = self.unicode.graphemeIterator(first_half);
+    var col: u16 = 0;
+    var i: u16 = 0;
+    while (first_iter.next()) |grapheme| {
+        if (i < self.draw_offset) {
+            i += 1;
+            continue;
+        }
+        const g = grapheme.bytes(first_half);
+        const w: u8 = @intCast(ctx.stringWidth(g));
+        if (col + w >= max_width) {
+            surface.writeCell(max_width - 1, 0, .{
+                .char = ellipsis,
+                .style = style,
+            });
+            break;
+        }
+        surface.writeCell(@intCast(col), 0, .{
+            .char = .{
+                .grapheme = g,
+                .width = w,
+            },
+            .style = style,
+        });
+        col += w;
+        i += 1;
+        if (i == cursor_idx) self.prev_cursor_col = col;
+    }
+    const second_half = self.buf.secondHalf();
+    var second_iter = self.unicode.graphemeIterator(second_half);
+    while (second_iter.next()) |grapheme| {
+        if (i < self.draw_offset) {
+            i += 1;
+            continue;
+        }
+        const g = grapheme.bytes(second_half);
+        const w: u8 = @intCast(ctx.stringWidth(g));
+        if (col + w > max_width) {
+            surface.writeCell(max_width - 1, 0, .{
+                .char = ellipsis,
+                .style = style,
+            });
+            break;
+        }
+        surface.writeCell(@intCast(col), 0, .{
+            .char = .{
+                .grapheme = g,
+                .width = w,
+            },
+            .style = style,
+        });
+        col += w;
+        i += 1;
+        if (i == cursor_idx) self.prev_cursor_col = col;
+    }
+    if (self.draw_offset > 0) {
+        surface.writeCell(0, 0, .{
+            .char = ellipsis,
+            .style = style,
+        });
+    }
+    surface.cursor = .{ .col = @intCast(self.prev_cursor_col), .row = 0 };
+    return surface;
+    // win.showCursor(self.prev_cursor_col, 0);
+}
+
+pub fn clearAndFree(self: *TextField) void {
+    self.buf.clearAndFree();
+    self.reset();
+}
+
+pub fn clearRetainingCapacity(self: *TextField) void {
+    self.buf.clearRetainingCapacity();
+    self.reset();
+}
+
+pub fn toOwnedSlice(self: *TextField) ![]const u8 {
+    defer self.reset();
+    return self.buf.toOwnedSlice();
+}
+
+pub fn reset(self: *TextField) void {
+    self.draw_offset = 0;
+    self.prev_cursor_col = 0;
+    self.prev_cursor_idx = 0;
+}
+
+// returns the number of bytes before the cursor
+pub fn byteOffsetToCursor(self: TextField) usize {
+    return self.buf.cursor;
+}
+
+pub fn deleteToEnd(self: *TextField) void {
+    self.buf.growGapRight(self.buf.secondHalf().len);
+}
+
+pub fn deleteToStart(self: *TextField) void {
+    self.buf.growGapLeft(self.buf.cursor);
+}
+
+pub fn deleteBeforeCursor(self: *TextField) void {
+    // We need to find the size of the last grapheme in the first half
+    var iter = self.unicode.graphemeIterator(self.buf.firstHalf());
+    var len: usize = 0;
+    while (iter.next()) |grapheme| {
+        len = grapheme.len;
+    }
+    self.buf.growGapLeft(len);
+}
+
+pub fn deleteAfterCursor(self: *TextField) void {
+    var iter = self.unicode.graphemeIterator(self.buf.secondHalf());
+    const grapheme = iter.next() orelse return;
+    self.buf.growGapRight(grapheme.len);
+}
+
+/// Moves the cursor backward by words. If the character before the cursor is a space, the cursor is
+/// positioned just after the next previous space
+pub fn moveBackwardWordwise(self: *TextField) void {
+    const trimmed = std.mem.trimRight(u8, self.buf.firstHalf(), " ");
+    const idx = if (std.mem.lastIndexOfScalar(u8, trimmed, ' ')) |last|
+        last + 1
+    else
+        0;
+    self.buf.moveGapLeft(self.buf.cursor - idx);
+}
+
+pub fn moveForwardWordwise(self: *TextField) void {
+    const second_half = self.buf.secondHalf();
+    var i: usize = 0;
+    while (i < second_half.len and second_half[i] == ' ') : (i += 1) {}
+    const idx = std.mem.indexOfScalarPos(u8, second_half, i, ' ') orelse second_half.len;
+    self.buf.moveGapRight(idx);
+}
+
+pub fn deleteWordBefore(self: *TextField) void {
+    // Store current cursor position. Move one word backward. Delete after the cursor the bytes we
+    // moved
+    const pre = self.buf.cursor;
+    self.moveBackwardWordwise();
+    self.buf.growGapRight(pre - self.buf.cursor);
+}
+
+pub fn deleteWordAfter(self: *TextField) void {
+    // Store current cursor position. Move one word backward. Delete after the cursor the bytes we
+    // moved
+    const second_half = self.buf.secondHalf();
+    var i: usize = 0;
+    while (i < second_half.len and second_half[i] == ' ') : (i += 1) {}
+    const idx = std.mem.indexOfScalarPos(u8, second_half, i, ' ') orelse second_half.len;
+    self.buf.growGapRight(idx);
+}
+
+test "sliceToCursor" {
+    const alloc = std.testing.allocator_instance.allocator();
+    const unicode = try Unicode.init(alloc);
+    defer unicode.deinit();
+    var input = init(alloc, &unicode);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello, world");
+    input.cursorLeft();
+    input.cursorLeft();
+    input.cursorLeft();
+    var buf: [32]u8 = undefined;
+    try std.testing.expectEqualStrings("hello, wo", input.sliceToCursor(&buf));
+    input.cursorRight();
+    try std.testing.expectEqualStrings("hello, wor", input.sliceToCursor(&buf));
+}
+
+pub const Buffer = struct {
+    allocator: std.mem.Allocator,
+    buffer: []u8,
+    cursor: usize,
+    gap_size: usize,
+
+    pub fn init(allocator: std.mem.Allocator) Buffer {
+        return .{
+            .allocator = allocator,
+            .buffer = &.{},
+            .cursor = 0,
+            .gap_size = 0,
+        };
+    }
+
+    pub fn deinit(self: *Buffer) void {
+        self.allocator.free(self.buffer);
+    }
+
+    pub fn firstHalf(self: Buffer) []const u8 {
+        return self.buffer[0..self.cursor];
+    }
+
+    pub fn secondHalf(self: Buffer) []const u8 {
+        return self.buffer[self.cursor + self.gap_size ..];
+    }
+
+    pub fn grow(self: *Buffer, n: usize) std.mem.Allocator.Error!void {
+        // Always grow by 512 bytes
+        const new_size = self.buffer.len + n + 512;
+        // Allocate the new memory
+        const new_memory = try self.allocator.alloc(u8, new_size);
+        // Copy the first half
+        @memcpy(new_memory[0..self.cursor], self.firstHalf());
+        // Copy the second half
+        const second_half = self.secondHalf();
+        @memcpy(new_memory[new_size - second_half.len ..], second_half);
+        self.allocator.free(self.buffer);
+        self.buffer = new_memory;
+        self.gap_size = new_size - second_half.len - self.cursor;
+    }
+
+    pub fn insertSliceAtCursor(self: *Buffer, slice: []const u8) std.mem.Allocator.Error!void {
+        if (slice.len == 0) return;
+        if (self.gap_size <= slice.len) try self.grow(slice.len);
+        @memcpy(self.buffer[self.cursor .. self.cursor + slice.len], slice);
+        self.cursor += slice.len;
+        self.gap_size -= slice.len;
+    }
+
+    /// Move the gap n bytes to the left
+    pub fn moveGapLeft(self: *Buffer, n: usize) void {
+        const new_idx = self.cursor -| n;
+        const dst = self.buffer[new_idx + self.gap_size ..];
+        const src = self.buffer[new_idx..self.cursor];
+        std.mem.copyForwards(u8, dst, src);
+        self.cursor = new_idx;
+    }
+
+    pub fn moveGapRight(self: *Buffer, n: usize) void {
+        const new_idx = self.cursor + n;
+        const dst = self.buffer[self.cursor..];
+        const src = self.buffer[self.cursor + self.gap_size .. new_idx + self.gap_size];
+        std.mem.copyForwards(u8, dst, src);
+        self.cursor = new_idx;
+    }
+
+    /// grow the gap by moving the cursor n bytes to the left
+    pub fn growGapLeft(self: *Buffer, n: usize) void {
+        // gap grows by the delta
+        self.gap_size += n;
+        self.cursor -|= n;
+    }
+
+    /// grow the gap by removing n bytes after the cursor
+    pub fn growGapRight(self: *Buffer, n: usize) void {
+        self.gap_size = @min(self.gap_size + n, self.buffer.len - self.cursor);
+    }
+
+    pub fn clearAndFree(self: *Buffer) void {
+        self.cursor = 0;
+        self.allocator.free(self.buffer);
+        self.buffer = &.{};
+        self.gap_size = 0;
+    }
+
+    pub fn clearRetainingCapacity(self: *Buffer) void {
+        self.cursor = 0;
+        self.gap_size = self.buffer.len;
+    }
+
+    pub fn toOwnedSlice(self: *Buffer) std.mem.Allocator.Error![]const u8 {
+        const slice = try self.dupe();
+        self.clearAndFree();
+        return slice;
+    }
+
+    pub fn realLength(self: *const Buffer) usize {
+        return self.firstHalf().len + self.secondHalf().len;
+    }
+
+    pub fn dupe(self: *const Buffer) std.mem.Allocator.Error![]const u8 {
+        const first_half = self.firstHalf();
+        const second_half = self.secondHalf();
+        const buf = try self.allocator.alloc(u8, first_half.len + second_half.len);
+        @memcpy(buf[0..first_half.len], first_half);
+        @memcpy(buf[first_half.len..], second_half);
+        return buf;
+    }
+};
+
+test "TextField.zig: Buffer" {
+    var gap_buf = Buffer.init(std.testing.allocator);
+    defer gap_buf.deinit();
+
+    try gap_buf.insertSliceAtCursor("abc");
+    try std.testing.expectEqualStrings("abc", gap_buf.firstHalf());
+    try std.testing.expectEqualStrings("", gap_buf.secondHalf());
+
+    gap_buf.moveGapLeft(1);
+    try std.testing.expectEqualStrings("ab", gap_buf.firstHalf());
+    try std.testing.expectEqualStrings("c", gap_buf.secondHalf());
+
+    try gap_buf.insertSliceAtCursor(" ");
+    try std.testing.expectEqualStrings("ab ", gap_buf.firstHalf());
+    try std.testing.expectEqualStrings("c", gap_buf.secondHalf());
+
+    gap_buf.growGapLeft(1);
+    try std.testing.expectEqualStrings("ab", gap_buf.firstHalf());
+    try std.testing.expectEqualStrings("c", gap_buf.secondHalf());
+    try std.testing.expectEqual(2, gap_buf.cursor);
+
+    gap_buf.growGapRight(1);
+    try std.testing.expectEqualStrings("ab", gap_buf.firstHalf());
+    try std.testing.expectEqualStrings("", gap_buf.secondHalf());
+    try std.testing.expectEqual(2, gap_buf.cursor);
+}
+
+test TextField {
+    // Boiler plate draw context init
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    // Create some object which reacts to text field changes
+    const Foo = struct {
+        allocator: std.mem.Allocator,
+        text: []const u8,
+
+        fn onChange(ptr: ?*anyopaque, ctx: *vxfw.EventContext, str: []const u8) anyerror!void {
+            const foo: *@This() = @ptrCast(@alignCast(ptr));
+            foo.text = try foo.allocator.dupe(u8, str);
+            ctx.consumeAndRedraw();
+        }
+    };
+    var foo: Foo = .{ .text = "", .allocator = arena.allocator() };
+
+    // Text field expands to the width, so it can't be null. It is always 1 line tall
+    const draw_ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 8, .height = 1 },
+    };
+    _ = draw_ctx;
+
+    var ctx: vxfw.EventContext = .{
+        .cmds = vxfw.CommandList.init(arena.allocator()),
+    };
+
+    // Enough boiler plate...Create the text field
+    var text_field = TextField.init(std.testing.allocator, &ucd);
+    defer text_field.deinit();
+    text_field.onChange = Foo.onChange;
+    text_field.onSubmit = Foo.onChange;
+    text_field.userdata = &foo;
+
+    const tf_widget = text_field.widget();
+    // Send some key events to the widget
+    try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'H', .text = "H" } });
+    // The foo object stores the last text that we saw from an onChange call
+    try std.testing.expectEqualStrings("H", foo.text);
+    try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'e', .text = "e" } });
+    try std.testing.expectEqualStrings("He", foo.text);
+    try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'l', .text = "l" } });
+    try std.testing.expectEqualStrings("Hel", foo.text);
+    try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'l', .text = "l" } });
+    try std.testing.expectEqualStrings("Hell", foo.text);
+    try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'o', .text = "o" } });
+    try std.testing.expectEqualStrings("Hello", foo.text);
+
+    // An arrow moves the cursor. The text doesn't change
+    try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.left } });
+    try std.testing.expectEqualStrings("Hello", foo.text);
+
+    try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = '_', .text = "_" } });
+    try std.testing.expectEqualStrings("Hell_o", foo.text);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -8,6 +8,8 @@ const assert = std.debug.assert;
 
 const Allocator = std.mem.Allocator;
 
+pub const App = @import("App.zig");
+
 pub const CommandList = std.ArrayList(Command);
 
 pub const UserEvent = struct {
@@ -421,12 +423,16 @@ test "SubSurface: containsPoint" {
     try testing.expect(!surf.containsPoint(.{ .row = 12, .col = 2 }));
 }
 
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}
+
 test "All widgets have a doctest and refAllDecls test" {
     // This test goes through every file in src/ and checks that it has a doctest (the filename
     // stripped of ".zig" matches a test name) and a test called "refAllDecls". It makes no
     // guarantees about the quality of the test, but it does ensure it exists which at least makes
     // it easy to fail CI early, or spot bad tests vs non-existant tests
-    const excludes = &[_][]const u8{"vxfw.zig"};
+    const excludes = &[_][]const u8{ "vxfw.zig", "App.zig" };
 
     var cwd = try std.fs.cwd().openDir("./src/vxfw", .{ .iterate = true });
     var iter = cwd.iterate();

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -11,6 +11,7 @@ const Allocator = std.mem.Allocator;
 pub const App = @import("App.zig");
 
 // Widgets
+pub const RichText = @import("RichText.zig");
 pub const Text = @import("Text.zig");
 
 pub const CommandList = std.ArrayList(Command);

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -14,6 +14,7 @@ pub const App = @import("App.zig");
 pub const ListView = @import("ListView.zig");
 pub const RichText = @import("RichText.zig");
 pub const Text = @import("Text.zig");
+pub const TextField = @import("TextField.zig");
 
 pub const CommandList = std.ArrayList(Command);
 

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -1,0 +1,471 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const grapheme = vaxis.grapheme;
+const testing = std.testing;
+
+const assert = std.debug.assert;
+
+const Allocator = std.mem.Allocator;
+
+pub const CommandList = std.ArrayList(Command);
+
+pub const UserEvent = struct {
+    name: []const u8,
+    data: ?*const anyopaque = null,
+};
+
+pub const Event = union(enum) {
+    key_press: vaxis.Key,
+    key_release: vaxis.Key,
+    mouse: vaxis.Mouse,
+    focus_in, // window has gained focus
+    focus_out, // window has lost focus
+    paste_start, // bracketed paste start
+    paste_end, // bracketed paste end
+    paste: []const u8, // osc 52 paste, caller must free
+    color_report: vaxis.Color.Report, // osc 4, 10, 11, 12 response
+    color_scheme: vaxis.Color.Scheme, // light / dark OS theme changes
+    winsize: vaxis.Winsize, // the window size has changed. This event is always sent when the loop is started
+    app: UserEvent, // A custom event from the app
+    tick, // An event from a Tick command
+    init, // sent when the application starts
+    mouse_leave, // The mouse has left the widget
+};
+
+pub const Tick = struct {
+    deadline_ms: i64,
+    widget: Widget,
+
+    pub fn lessThan(_: void, lhs: Tick, rhs: Tick) bool {
+        return lhs.deadline_ms > rhs.deadline_ms;
+    }
+
+    pub fn in(ms: u32, widget: Widget) Command {
+        const now = std.time.milliTimestamp();
+        return .{ .tick = .{
+            .deadline_ms = now + ms,
+            .widget = widget,
+        } };
+    }
+};
+
+pub const Command = union(enum) {
+    /// Callback the event with a tick event at the specified deadlline
+    tick: Tick,
+    /// Change the mouse shape. This also has an implicit redraw
+    set_mouse_shape: vaxis.Mouse.Shape,
+    /// Request that this widget receives focus
+    request_focus: Widget,
+};
+
+pub const EventContext = struct {
+    phase: Phase = .at_target,
+    cmds: CommandList,
+
+    /// The event was handled, do not pass it on
+    consume_event: bool = false,
+    /// Tells the event loop to redraw the UI
+    redraw: bool = true,
+    /// Quit the application
+    quit: bool = false,
+
+    pub const Phase = enum {
+        // TODO: Capturing phase
+        // capturing,
+        at_target,
+        bubbling,
+    };
+
+    pub fn addCmd(self: *EventContext, cmd: Command) Allocator.Error!void {
+        try self.cmds.append(cmd);
+    }
+
+    pub fn tick(self: *EventContext, ms: u32, widget: Widget) Allocator.Error!void {
+        try self.addCmd(Tick.in(ms, widget));
+    }
+
+    pub fn consumeAndRedraw(self: *EventContext) void {
+        self.consume_event = true;
+        self.redraw = true;
+    }
+
+    pub fn consumeEvent(self: *EventContext) void {
+        self.consume_event = true;
+    }
+
+    pub fn setMouseShape(self: *EventContext, shape: vaxis.Mouse.Shape) Allocator.Error!void {
+        try self.addCmd(.{ .set_mouse_shape = shape });
+        self.redraw = true;
+    }
+
+    pub fn requestFocus(self: *EventContext, widget: Widget) Allocator.Error!void {
+        try self.addCmd(.{ .request_focus = widget });
+    }
+};
+
+pub const DrawContext = struct {
+    // Allocator backed by an arena. Widgets do not need to free their own resources, they will be
+    // freed after rendering
+    arena: std.mem.Allocator,
+    // Constraints
+    min: Size,
+    max: MaxSize,
+
+    // Unicode stuff
+    var unicode: ?*const vaxis.Unicode = null;
+    var width_method: vaxis.gwidth.Method = .unicode;
+
+    pub fn init(ucd: *const vaxis.Unicode, method: vaxis.gwidth.Method) void {
+        DrawContext.unicode = ucd;
+        DrawContext.width_method = method;
+    }
+
+    pub fn stringWidth(_: DrawContext, str: []const u8) usize {
+        assert(DrawContext.unicode != null); // DrawContext not initialized
+        return vaxis.gwidth.gwidth(
+            str,
+            DrawContext.width_method,
+            &DrawContext.unicode.?.width_data,
+        );
+    }
+
+    pub fn graphemeIterator(_: DrawContext, str: []const u8) grapheme.Iterator {
+        assert(DrawContext.unicode != null); // DrawContext not initialized
+        return DrawContext.unicode.?.graphemeIterator(str);
+    }
+
+    pub fn withConstraints(self: DrawContext, min: Size, max: MaxSize) DrawContext {
+        return .{
+            .arena = self.arena,
+            .min = min,
+            .max = max,
+        };
+    }
+};
+
+pub const Size = struct {
+    width: u16 = 0,
+    height: u16 = 0,
+};
+
+pub const MaxSize = struct {
+    width: ?u16 = null,
+    height: ?u16 = null,
+
+    /// Returns true if the row would fall outside of this height. A null height value is infinite
+    /// and always returns false
+    pub fn outsideHeight(self: MaxSize, row: u16) bool {
+        const max = self.height orelse return false;
+        return row >= max;
+    }
+
+    /// Returns true if the col would fall outside of this width. A null width value is infinite
+    /// and always returns false
+    pub fn outsideWidth(self: MaxSize, col: u16) bool {
+        const max = self.width orelse return false;
+        return col >= max;
+    }
+
+    /// Asserts that neither height nor width are null
+    pub fn size(self: MaxSize) Size {
+        assert(self.width != null);
+        assert(self.height != null);
+        return .{
+            .width = self.width.?,
+            .height = self.height.?,
+        };
+    }
+};
+
+/// The Widget interface
+pub const Widget = struct {
+    userdata: *anyopaque,
+    eventHandler: *const fn (userdata: *anyopaque, ctx: *EventContext, event: Event) anyerror!void,
+    drawFn: *const fn (userdata: *anyopaque, ctx: DrawContext) Allocator.Error!Surface,
+
+    pub fn handleEvent(self: Widget, ctx: *EventContext, event: Event) anyerror!void {
+        return self.eventHandler(self.userdata, ctx, event);
+    }
+
+    pub fn draw(self: Widget, ctx: DrawContext) Allocator.Error!Surface {
+        return self.drawFn(self.userdata, ctx);
+    }
+
+    /// Returns true if the Widgets point to the same widget instance
+    pub fn eql(self: Widget, other: Widget) bool {
+        return @intFromPtr(self.userdata) == @intFromPtr(other.userdata) and
+            @intFromPtr(self.eventHandler) == @intFromPtr(other.eventHandler) and
+            @intFromPtr(self.drawFn) == @intFromPtr(other.drawFn);
+    }
+};
+
+pub const FlexItem = struct {
+    widget: Widget,
+    /// A value of zero means the child will have it's inherent size. Any value greater than zero
+    /// and the remaining space will be proportioned to each item
+    flex: u8 = 1,
+
+    pub fn init(child: Widget, flex: u8) FlexItem {
+        return .{ .widget = child, .flex = flex };
+    }
+};
+
+pub const Point = struct {
+    row: u16,
+    col: u16,
+};
+
+pub const RelativePoint = struct {
+    row: i17,
+    col: i17,
+};
+
+/// Result of a hit test
+pub const HitResult = struct {
+    local: Point,
+    widget: Widget,
+};
+
+pub const CursorState = struct {
+    /// Local coordinates
+    row: u16,
+    /// Local coordinates
+    col: u16,
+    shape: vaxis.Cell.CursorShape = .default,
+};
+
+pub const Surface = struct {
+    /// Size of this surface
+    size: Size,
+    /// The widget this surface belongs to
+    widget: Widget,
+
+    /// If this widget / Surface is focusable
+    focusable: bool = false,
+    /// If this widget can handle mouse events
+    handles_mouse: bool = false,
+
+    /// Cursor state
+    cursor: ?CursorState = null,
+
+    /// Contents of this surface. Must be len == 0 or  len == size.width * size.height
+    buffer: []vaxis.Cell,
+
+    children: []SubSurface,
+
+    /// Creates a slice of vaxis.Cell's equal to size.width * size.height
+    pub fn createBuffer(allocator: Allocator, size: Size) Allocator.Error![]vaxis.Cell {
+        const buffer = try allocator.alloc(vaxis.Cell, size.width * size.height);
+        @memset(buffer, .{ .default = true });
+        return buffer;
+    }
+
+    pub fn init(allocator: Allocator, widget: Widget, size: Size) Allocator.Error!Surface {
+        return .{
+            .size = size,
+            .widget = widget,
+            .buffer = try Surface.createBuffer(allocator, size),
+            .children = &.{},
+        };
+    }
+
+    pub fn initWithChildren(
+        allocator: Allocator,
+        widget: Widget,
+        size: Size,
+        children: []SubSurface,
+    ) Allocator.Error!Surface {
+        return .{
+            .size = size,
+            .widget = widget,
+            .buffer = try Surface.createBuffer(allocator, size),
+            .children = children,
+        };
+    }
+
+    pub fn writeCell(self: Surface, col: u16, row: u16, cell: vaxis.Cell) void {
+        if (self.size.width <= col) return;
+        if (self.size.height <= row) return;
+        const i = (row * self.size.width) + col;
+        assert(i < self.buffer.len);
+        self.buffer[i] = cell;
+    }
+
+    pub fn readCell(self: Surface, col: usize, row: usize) vaxis.Cell {
+        assert(col < self.size.width and row < self.size.height);
+        const i = (row * self.size.width) + col;
+        assert(i < self.buffer.len);
+        return self.buffer[i];
+    }
+
+    /// Creates a new surface of the same width, with the buffer trimmed to a given height
+    pub fn trimHeight(self: Surface, height: u16) Surface {
+        assert(height <= self.size.height);
+        return .{
+            .size = .{ .width = self.size.width, .height = height },
+            .widget = self.widget,
+            .buffer = self.buffer[0 .. self.size.width * height],
+            .children = self.children,
+            .focusable = self.focusable,
+            .handles_mouse = self.handles_mouse,
+        };
+    }
+
+    /// Walks the Surface tree to produce a list of all widgets that intersect Point. Point will
+    /// always be translated to local Surface coordinates. Asserts that this Surface does contain Point
+    pub fn hitTest(self: Surface, list: *std.ArrayList(HitResult), point: Point) Allocator.Error!void {
+        assert(point.col < self.size.width and point.row < self.size.height);
+        if (self.handles_mouse)
+            try list.append(.{ .local = point, .widget = self.widget });
+        for (self.children) |child| {
+            if (!child.containsPoint(point)) continue;
+            const child_point: Point = .{
+                .row = @intCast(point.row - child.origin.row),
+                .col = @intCast(point.col - child.origin.col),
+            };
+            try child.surface.hitTest(list, child_point);
+        }
+    }
+
+    /// Copies all cells from Surface to Window
+    pub fn render(self: Surface, win: vaxis.Window, focused: Widget) void {
+        // render self first
+        if (self.buffer.len > 0) {
+            assert(self.buffer.len == self.size.width * self.size.height);
+            for (self.buffer, 0..) |cell, i| {
+                const row = i / self.size.width;
+                const col = i % self.size.width;
+                win.writeCell(@intCast(col), @intCast(row), cell);
+            }
+        }
+
+        if (self.cursor) |cursor| {
+            if (self.widget.eql(focused)) {
+                win.showCursor(cursor.col, cursor.row);
+                win.setCursorShape(cursor.shape);
+            }
+        }
+
+        // Sort children by z-index
+        std.mem.sort(SubSurface, self.children, {}, SubSurface.lessThan);
+
+        // for each child, we make a window and render to it
+        for (self.children) |child| {
+            const child_win = win.child(.{
+                .x_off = @intCast(child.origin.col),
+                .y_off = @intCast(child.origin.row),
+                .width = @intCast(child.surface.size.width),
+                .height = @intCast(child.surface.size.height),
+            });
+            child.surface.render(child_win, focused);
+        }
+    }
+
+    /// Returns true if the surface satisfies a set of constraints
+    pub fn satisfiesConstraints(self: Surface, min: Size, max: Size) bool {
+        return self.size.width < min.width and
+            self.size.width > max.width and
+            self.size.height < min.height and
+            self.size.height > max.height;
+    }
+};
+
+pub const SubSurface = struct {
+    /// Origin relative to parent
+    origin: RelativePoint,
+    /// This surface
+    surface: Surface,
+    /// z-index relative to siblings
+    z_index: u8 = 0,
+
+    pub fn lessThan(_: void, lhs: SubSurface, rhs: SubSurface) bool {
+        return lhs.z_index < rhs.z_index;
+    }
+
+    /// Returns true if this SubSurface contains Point. Point must be in parent local units
+    pub fn containsPoint(self: SubSurface, point: Point) bool {
+        return point.col >= self.origin.col and
+            point.row >= self.origin.row and
+            point.col < (self.origin.col + self.surface.size.width) and
+            point.row < (self.origin.row + self.surface.size.height);
+    }
+};
+
+/// A noop event handler for widgets which don't require any event handling
+pub fn noopEventHandler(_: *anyopaque, _: *EventContext, _: Event) anyerror!void {}
+
+test {
+    std.testing.refAllDecls(@This());
+}
+
+test "SubSurface: containsPoint" {
+    const surf: SubSurface = .{
+        .origin = .{ .row = 2, .col = 2 },
+        .surface = .{
+            .size = .{ .width = 10, .height = 10 },
+            .widget = undefined,
+            .children = &.{},
+            .buffer = &.{},
+        },
+        .z_index = 0,
+    };
+
+    try testing.expect(surf.containsPoint(.{ .row = 2, .col = 2 }));
+    try testing.expect(surf.containsPoint(.{ .row = 3, .col = 3 }));
+    try testing.expect(surf.containsPoint(.{ .row = 11, .col = 11 }));
+
+    try testing.expect(!surf.containsPoint(.{ .row = 1, .col = 1 }));
+    try testing.expect(!surf.containsPoint(.{ .row = 12, .col = 12 }));
+    try testing.expect(!surf.containsPoint(.{ .row = 2, .col = 12 }));
+    try testing.expect(!surf.containsPoint(.{ .row = 12, .col = 2 }));
+}
+
+test "All widgets have a doctest and refAllDecls test" {
+    // This test goes through every file in src/ and checks that it has a doctest (the filename
+    // stripped of ".zig" matches a test name) and a test called "refAllDecls". It makes no
+    // guarantees about the quality of the test, but it does ensure it exists which at least makes
+    // it easy to fail CI early, or spot bad tests vs non-existant tests
+    const excludes = &[_][]const u8{"vxfw.zig"};
+
+    var cwd = try std.fs.cwd().openDir("./src/vxfw", .{ .iterate = true });
+    var iter = cwd.iterate();
+    defer cwd.close();
+    outer: while (try iter.next()) |file| {
+        if (file.kind != .file) continue;
+        for (excludes) |ex| if (std.mem.eql(u8, ex, file.name)) continue :outer;
+
+        const container_name = if (std.mem.lastIndexOf(u8, file.name, ".zig")) |idx|
+            file.name[0..idx]
+        else
+            continue;
+        const data = try cwd.readFileAllocOptions(std.testing.allocator, file.name, 10_000_000, null, @alignOf(u8), 0x00);
+        defer std.testing.allocator.free(data);
+        var ast = try std.zig.Ast.parse(std.testing.allocator, data, .zig);
+        defer ast.deinit(std.testing.allocator);
+
+        var has_doctest: bool = false;
+        var has_refAllDecls: bool = false;
+        for (ast.rootDecls()) |root_decl| {
+            const decl = ast.nodes.get(root_decl);
+            switch (decl.tag) {
+                .test_decl => {
+                    const test_name = ast.tokenSlice(decl.data.lhs);
+                    if (std.mem.eql(u8, "\"refAllDecls\"", test_name))
+                        has_refAllDecls = true
+                    else if (std.mem.eql(u8, container_name, test_name))
+                        has_doctest = true;
+                },
+                else => continue,
+            }
+        }
+        if (!has_doctest) {
+            std.log.err("file {s} has no doctest", .{file.name});
+            return error.TestExpectedDoctest;
+        }
+        if (!has_refAllDecls) {
+            std.log.err("file {s} has no 'refAllDecls' test", .{file.name});
+            return error.TestExpectedRefAllDecls;
+        }
+    }
+}

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -11,6 +11,7 @@ const Allocator = std.mem.Allocator;
 pub const App = @import("App.zig");
 
 // Widgets
+pub const ListView = @import("ListView.zig");
 pub const RichText = @import("RichText.zig");
 pub const Text = @import("Text.zig");
 

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -10,6 +10,9 @@ const Allocator = std.mem.Allocator;
 
 pub const App = @import("App.zig");
 
+// Widgets
+pub const Text = @import("Text.zig");
+
 pub const CommandList = std.ArrayList(Command);
 
 pub const UserEvent = struct {

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -18,6 +18,7 @@ pub const FlexRow = @import("FlexRow.zig");
 pub const ListView = @import("ListView.zig");
 pub const Padding = @import("Padding.zig");
 pub const RichText = @import("RichText.zig");
+pub const SizedBox = @import("SizedBox.zig");
 pub const Text = @import("Text.zig");
 pub const TextField = @import("TextField.zig");
 

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -14,6 +14,7 @@ pub const App = @import("App.zig");
 pub const Button = @import("Button.zig");
 pub const Center = @import("Center.zig");
 pub const FlexColumn = @import("FlexColumn.zig");
+pub const FlexRow = @import("FlexRow.zig");
 pub const ListView = @import("ListView.zig");
 pub const RichText = @import("RichText.zig");
 pub const Text = @import("Text.zig");

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -86,8 +86,7 @@ pub const EventContext = struct {
     quit: bool = false,
 
     pub const Phase = enum {
-        // TODO: Capturing phase
-        // capturing,
+        capturing,
         at_target,
         bubbling,
     };
@@ -196,11 +195,13 @@ pub const MaxSize = struct {
 /// The Widget interface
 pub const Widget = struct {
     userdata: *anyopaque,
-    eventHandler: *const fn (userdata: *anyopaque, ctx: *EventContext, event: Event) anyerror!void,
+    eventHandler: ?*const fn (userdata: *anyopaque, ctx: *EventContext, event: Event) anyerror!void = null,
     drawFn: *const fn (userdata: *anyopaque, ctx: DrawContext) Allocator.Error!Surface,
 
     pub fn handleEvent(self: Widget, ctx: *EventContext, event: Event) anyerror!void {
-        return self.eventHandler(self.userdata, ctx, event);
+        if (self.eventHandler) |handle| {
+            return handle(self.userdata, ctx, event);
+        }
     }
 
     pub fn draw(self: Widget, ctx: DrawContext) Allocator.Error!Surface {

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -19,6 +19,7 @@ pub const ListView = @import("ListView.zig");
 pub const Padding = @import("Padding.zig");
 pub const RichText = @import("RichText.zig");
 pub const SizedBox = @import("SizedBox.zig");
+pub const Spinner = @import("Spinner.zig");
 pub const Text = @import("Text.zig");
 pub const TextField = @import("TextField.zig");
 

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -16,6 +16,7 @@ pub const Center = @import("Center.zig");
 pub const FlexColumn = @import("FlexColumn.zig");
 pub const FlexRow = @import("FlexRow.zig");
 pub const ListView = @import("ListView.zig");
+pub const Padding = @import("Padding.zig");
 pub const RichText = @import("RichText.zig");
 pub const Text = @import("Text.zig");
 pub const TextField = @import("TextField.zig");

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -11,6 +11,7 @@ const Allocator = std.mem.Allocator;
 pub const App = @import("App.zig");
 
 // Widgets
+pub const Center = @import("Center.zig");
 pub const ListView = @import("ListView.zig");
 pub const RichText = @import("RichText.zig");
 pub const Text = @import("Text.zig");

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -13,6 +13,7 @@ pub const App = @import("App.zig");
 // Widgets
 pub const Button = @import("Button.zig");
 pub const Center = @import("Center.zig");
+pub const FlexColumn = @import("FlexColumn.zig");
 pub const ListView = @import("ListView.zig");
 pub const RichText = @import("RichText.zig");
 pub const Text = @import("Text.zig");

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -19,6 +19,7 @@ pub const ListView = @import("ListView.zig");
 pub const Padding = @import("Padding.zig");
 pub const RichText = @import("RichText.zig");
 pub const SizedBox = @import("SizedBox.zig");
+pub const SplitView = @import("SplitView.zig");
 pub const Spinner = @import("Spinner.zig");
 pub const Text = @import("Text.zig");
 pub const TextField = @import("TextField.zig");

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -11,6 +11,7 @@ const Allocator = std.mem.Allocator;
 pub const App = @import("App.zig");
 
 // Widgets
+pub const Button = @import("Button.zig");
 pub const Center = @import("Center.zig");
 pub const ListView = @import("ListView.zig");
 pub const RichText = @import("RichText.zig");


### PR DESCRIPTION
Add an application framework which provides a standard widget interface, a set
of common widgets, and a high level application layer which manages all events.
The intent is to provide a high level framework that provides a more familiar
application development experience - similar to what one might see in Flutter, a
browser, GTK, etc.

The design is heavily influenced by Flutter, with a mix of Elm in there as well.
Notably this design uses far more mutation than in either, but this works to our
advantage in a language like Zig.

A widget must provide two functions: `handleEvent` and `draw`. Handle event
takes a context and an event. The context includes an `ArrayList(Command)` which
the widget may add commands to - such as "set the mouse shape to pointer", "give
this widget focus", "schedule an event to occur in 500 ms". The `draw` function
takes in a context as well. The `DrawContext` provides minimum and maximum size
constraints for the widget, as well as an arena allocator. The arena must be
used for all per-frame allocations in the draw context. `draw` returns a
`Surface`, which is an allocated buffer of terminal `Cell`s. From here, the
application layer builds a tree of `Surface`s which it uses to composite the
final scene, hit test for mouse events, and manage focus.

Unlike Elm, input events are sent to the focused widget instead of the root. The
design allows for adding a capturing phase, target phase, and bubbling phase for
all input events. Currently we only use target and bubbling (like Flutter), but
this can be extended to include capturing as well.
