### PR TITLE
fix Window scroll

### DIFF
--- a/src/Window.zig
+++ b/src/Window.zig
@@ -438,10 +438,10 @@ pub fn scroll(self: Window, n: u16) void {
     var row: u16 = @max(self.y_off, 0);
     const first_col: u16 = @max(self.x_off, 0);
     while (row < self.height - n) : (row += 1) {
-        const dst_start = (row * self.width) + first_col;
+        const dst_start = (row * self.screen.width) + first_col;
         const dst_end = dst_start + self.width;
 
-        const src_start = ((row + n) * self.width) + first_col;
+        const src_start = ((row + n) * self.screen.width) + first_col;
         const src_end = src_start + self.width;
         @memcpy(self.screen.buf[dst_start..dst_end], self.screen.buf[src_start..src_end]);
     }


### PR DESCRIPTION
When doing something like this

```zig
const win = vx.window();
const child = win.child(.{
    .width = .{ .limit = 6 },
});
_ = try child.printSegment(
    .{ .text = "Hello there how are you?" },
    .{ .wrap = .word },
);
child.scroll(1);
```

The output is

```
                                                                                                 there
                                                                                                 how
are
you?
```

while it should be

```
there
how
are
you?
```

By using the screen width instead of the child one the scrolling gets fixed.