### PR TITLE
window: fix negative offset clip

### DIFF
--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -205,6 +205,8 @@ pub fn window(self: *Vaxis) Window {
     return .{
         .x_off = 0,
         .y_off = 0,
+        .parent_x_off = 0,
+        .parent_y_off = 0,
         .width = self.screen.width,
         .height = self.screen.height,
         .screen = &self.screen,


### PR DESCRIPTION
Accumulate any negative offsets in order to properly clip windows to
their parents. Previously, we only clipped if the window would be off
the screen from a negative offset. In the diagram below, we should
expect that if B is a child of A, it can't print in the non-overlapping
area. That is, B can only print in the overlapping region with A because
it is a child of A. This patch fixes this.

```
+-----------------------------------------------------+
|                                                     |
|              +--------+                             |
|              | B      |                             |
|              |    +---|-----+                       |
|              |    |   |     |                       |
|              +--------+     |                       |
|                   |         |                       |
|                   |      A  |                       |
|                   +---------+                       |
|                                                     |
|                                                     |
|                                                     |
+-----------------------------------------------------+
```