### PR TITLE
Add ScrollView and ScrollBars widgets

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,7 @@ pub fn build(b: *std.Build) void {
         fuzzy,
         image,
         main,
+        scroll,
         table,
         text_input,
         vaxis,

--- a/examples/scroll.zig
+++ b/examples/scroll.zig
@@ -83,6 +83,14 @@ const Model = struct {
                     }
                     return ctx.consumeAndRedraw();
                 }
+                if (key.matches('e', .{ .ctrl = true })) {
+                    if (self.scroll_view.estimated_content_height == null)
+                        self.scroll_view.estimated_content_height = 800
+                    else
+                        self.scroll_view.estimated_content_height = null;
+
+                    return ctx.consumeAndRedraw();
+                }
                 if (key.matches(vaxis.Key.tab, .{})) {
                     self.scroll_view.draw_cursor = !self.scroll_view.draw_cursor;
                     return ctx.consumeAndRedraw();

--- a/examples/scroll.zig
+++ b/examples/scroll.zig
@@ -1,0 +1,115 @@
+const std = @import("std");
+const vaxis = @import("vaxis");
+const vxfw = vaxis.vxfw;
+
+const Model = struct {
+    scroll_view: vxfw.ScrollView,
+    text: std.ArrayList(vxfw.RichText),
+
+    arena: std.heap.ArenaAllocator,
+
+    pub fn widget(self: *Model) vxfw.Widget {
+        return .{
+            .userdata = self,
+            .eventHandler = Model.typeErasedEventHandler,
+            .drawFn = Model.typeErasedDrawFn,
+        };
+    }
+
+    fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        switch (event) {
+            .key_press => |key| {
+                if (key.matches('c', .{ .ctrl = true })) {
+                    ctx.quit = true;
+                    return;
+                }
+                return self.scroll_view.handleEvent(ctx, event);
+            },
+            else => {},
+        }
+    }
+
+    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
+        const self: *Model = @ptrCast(@alignCast(ptr));
+        const max = ctx.max.size();
+
+        const scroll_view: vxfw.SubSurface = .{
+            .origin = .{ .row = 0, .col = 0 },
+            .surface = try self.scroll_view.draw(ctx),
+        };
+
+        const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
+        children[0] = scroll_view;
+
+        return .{
+            .size = max,
+            .widget = self.widget(),
+            .focusable = true,
+            .buffer = &.{},
+            .children = children,
+        };
+    }
+
+    fn widgetBuilder(ptr: *const anyopaque, idx: usize, _: usize) ?vxfw.Widget {
+        const self: *const Model = @ptrCast(@alignCast(ptr));
+        if (idx >= self.text.items.len) return null;
+
+        return self.text.items[idx].widget();
+    }
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+
+    const allocator = gpa.allocator();
+
+    var app = try vxfw.App.init(allocator);
+    errdefer app.deinit();
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+
+    const model = try allocator.create(Model);
+    defer allocator.destroy(model);
+    model.* = .{
+        .scroll_view = .{
+            .children = .{
+                .builder = .{
+                    .userdata = model,
+                    .buildFn = Model.widgetBuilder,
+                },
+            },
+        },
+        .text = std.ArrayList(vxfw.RichText).init(allocator),
+        .arena = arena,
+    };
+    defer model.text.deinit();
+
+    var lipsum = std.ArrayList([]const u8).init(allocator);
+    defer lipsum.deinit();
+
+    try lipsum.append("    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sit amet nunc porta, commodo tellus eu, blandit lectus. Aliquam dignissim rhoncus mi eu ultrices. Suspendisse lectus massa, bibendum sed lorem sit amet, egestas aliquam ante. Mauris venenatis nibh neque. Nulla a mi eget purus porttitor malesuada. Sed ac porta felis. Morbi ultricies urna nisi, et maximus elit convallis a. Morbi ut felis nec orci euismod congue efficitur egestas ex. Quisque eu feugiat magna. Pellentesque porttitor tortor ut iaculis dictum. Nulla erat neque, sollicitudin vitae enim nec, pharetra blandit tortor. Sed orci ante, condimentum vitae sodales in, sodales ut nulla. Suspendisse quam felis, aliquet ut neque a, lacinia sagittis turpis. Vivamus nec dui purus. Proin tempor nisl et porttitor consequat.");
+    try lipsum.append("    Vivamus elit massa, commodo in laoreet nec, scelerisque ac orci. Donec nec ante sit amet nisi ullamcorper dictum quis non enim. Proin ante libero, consequat sit amet semper a, vulputate non odio. Mauris ut suscipit lacus. Mauris nec dolor id ex mollis tempor at quis ligula. Integer varius commodo ipsum id gravida. Sed ut lobortis est, id egestas nunc. In fringilla ullamcorper porttitor. Donec quis dignissim arcu, vitae sagittis tortor. Sed tempor porttitor arcu, sit amet elementum est ornare id. Morbi rhoncus, ipsum eget tincidunt volutpat, mauris enim vestibulum nibh, mollis iaculis ante enim quis enim. Donec pharetra odio vel ex fringilla, ut laoreet ipsum commodo. Praesent tempus, leo a pellentesque sodales, erat ipsum pretium nulla, id faucibus sem turpis at nibh. Aenean ut dui luctus, vehicula felis vel, aliquam nulla.");
+    try lipsum.append("    Cras interdum mattis elit non varius. In condimentum velit a tellus sollicitudin interdum. Etiam pulvinar semper ex, eget congue ante tristique ut. Phasellus commodo magna magna, at fermentum tortor porttitor ac. Fusce a efficitur diam, a congue ante. Mauris maximus ultrices leo, non viverra ex hendrerit eu. Donec laoreet turpis nulla, eget imperdiet tortor mollis aliquam. Donec a est eget ante consequat rhoncus.");
+    try lipsum.append("    Morbi facilisis libero nec viverra imperdiet. Ut dictum faucibus bibendum. Vestibulum ut nisl eu magna sollicitudin elementum vel eu ante. Phasellus euismod ligula massa, vel rutrum elit hendrerit ut. Vivamus id luctus lectus, at ullamcorper leo. Pellentesque in risus finibus, viverra ligula sed, porta nisl. Aliquam pretium accumsan placerat. Etiam a elit posuere, varius erat sed, aliquet quam. Morbi finibus gravida erat, non imperdiet dolor sollicitudin dictum. Aenean eget ullamcorper lacus, et hendrerit lorem. Quisque sed varius mauris.");
+    try lipsum.append("    Nullam vitae euismod mauris, eu gravida dolor. Nunc vel urna laoreet justo faucibus tempus. Vestibulum tincidunt sagittis metus ac dignissim. Curabitur eleifend dolor consequat malesuada posuere. In hac habitasse platea dictumst. Fusce eget ipsum tincidunt, placerat orci ut, malesuada ante. Vivamus ultrices purus vel orci posuere, sed posuere eros porta. Vestibulum a tellus et tortor scelerisque varius. Pellentesque vel leo sed est semper bibendum. Mauris tellus ante, cursus et nunc vitae, dictum pellentesque ex. In tristique purus felis, non efficitur ante mollis id. Nulla quam nisi, suscipit sit amet mattis vel, placerat sit amet lectus. Vestibulum cursus auctor quam, at convallis felis euismod non. Sed nec magna nisi. Morbi scelerisque accumsan nunc, sed sagittis sem varius sit amet. Maecenas arcu dui, euismod et sem quis, condimentum blandit tellus.");
+    try lipsum.append("    Nullam auctor lobortis libero non viverra. Mauris a imperdiet eros, a luctus est. Integer pellentesque eros et metus rhoncus egestas. Suspendisse eu risus mauris. Mauris posuere nulla in justo pharetra molestie. Maecenas sagittis at nunc et finibus. Vestibulum quis leo ac mauris malesuada vestibulum vitae eu enim. Ut et maximus elit. Pellentesque lorem felis, tristique vitae posuere vitae, auctor tempus magna. Fusce cursus purus sit amet risus pulvinar, non egestas ligula imperdiet.");
+    try lipsum.append("    Proin rhoncus tincidunt congue. Curabitur pretium mauris eu erat iaculis semper. Vestibulum augue tortor, vehicula id maximus at, semper eu leo. Vivamus feugiat at purus eu dapibus. Mauris luctus sollicitudin nibh, in placerat est mattis vitae. Morbi ut risus felis. Etiam lobortis mollis diam, id tempor odio sollicitudin a. Morbi congue, lacus ac accumsan consequat, ipsum eros facilisis est, in congue metus ex nec ligula. Vestibulum dolor ligula, interdum nec iaculis vel, interdum a diam. Curabitur mattis, risus at rhoncus gravida, diam est viverra diam, ut mattis augue nulla sed lacus.");
+    try lipsum.append("    Duis rutrum orci sit amet dui imperdiet porta. In pulvinar imperdiet enim nec tristique. Etiam egestas pulvinar arcu, viverra mollis ipsum. Ut sit amet sapien nibh. Maecenas ut velit egestas, suscipit dolor vel, interdum tellus. Pellentesque faucibus euismod risus, ac vehicula erat sodales a. Aliquam egestas sit amet enim ac posuere. In id venenatis eros, et pharetra neque. Proin facilisis, odio id vehicula elementum, sapien ligula interdum dui, quis vestibulum est quam sit amet nisl. Aliquam in orci et felis aliquet tempus quis id magna. Sed interdum malesuada sem. Proin sagittis est metus, eu vestibulum nunc lacinia in. Vestibulum enim erat, cursus at justo at, porta feugiat quam. Phasellus vestibulum finibus nulla, at egestas augue imperdiet dapibus. Nunc in felis at ante congue interdum ut nec sapien.");
+    try lipsum.append("    Etiam lacinia ornare mauris, ut lacinia elit sollicitudin non. Morbi cursus dictum enim, et vulputate mi sollicitudin vel. Fusce rutrum augue justo. Phasellus et mauris tincidunt erat lacinia bibendum sed eu orci. Sed nunc lectus, dignissim sit amet ultricies sit amet, efficitur eu urna. Fusce feugiat malesuada ipsum nec congue. Praesent ultrices metus eu pulvinar laoreet. Maecenas pellentesque, metus ac lobortis rhoncus, ligula eros consequat urna, eget dictum lectus sem ut orci. Donec lobortis, lacus sed bibendum auctor, odio turpis suscipit odio, vitae feugiat leo metus ac lectus. Curabitur sed sem arcu.");
+    try lipsum.append("    Mauris nisi tortor, auctor venenatis turpis a, finibus condimentum lectus. Donec id velit odio. Curabitur ac varius lorem. Nam cursus quam in velit gravida, in bibendum purus fermentum. Sed non rutrum dui, nec ultrices ligula. Integer lacinia blandit nisl non sollicitudin. Praesent nec malesuada eros, sit amet tincidunt nunc.");
+
+    for (0..10) |_| {
+        for (lipsum.items) |paragraph| {
+            var spans = std.ArrayList(vxfw.RichText.TextSpan).init(arena.allocator());
+            try spans.append(.{ .text = paragraph });
+
+            try model.text.append(.{ .text = spans.items, .softwrap = true });
+        }
+    }
+
+    try app.run(model.widget(), .{});
+    app.deinit();
+}

--- a/examples/scroll.zig
+++ b/examples/scroll.zig
@@ -5,6 +5,7 @@ const vxfw = vaxis.vxfw;
 const ModelRow = struct {
     text: []const u8,
     idx: usize,
+    wrap_lines: bool = true,
 
     pub fn widget(self: *ModelRow) vxfw.Widget {
         return .{
@@ -29,7 +30,7 @@ const ModelRow = struct {
             )),
         };
 
-        const text_widget: vxfw.Text = .{ .text = self.text };
+        const text_widget: vxfw.Text = .{ .text = self.text, .softwrap = self.wrap_lines };
         const text_surf: vxfw.SubSurface = .{
             .origin = .{ .row = 0, .col = 6 },
             .surface = try text_widget.draw(ctx.withConstraints(
@@ -75,6 +76,12 @@ const Model = struct {
                 if (key.matches('c', .{ .ctrl = true })) {
                     ctx.quit = true;
                     return;
+                }
+                if (key.matches('w', .{ .ctrl = true })) {
+                    for (self.rows.items) |*row| {
+                        row.wrap_lines = !row.wrap_lines;
+                    }
+                    return ctx.consumeAndRedraw();
                 }
                 if (key.matches(vaxis.Key.tab, .{})) {
                     self.scroll_view.draw_cursor = !self.scroll_view.draw_cursor;

--- a/examples/scroll.zig
+++ b/examples/scroll.zig
@@ -148,6 +148,12 @@ pub fn main() !void {
                     .buildFn = Model.widgetBuilder,
                 },
             },
+            // NOTE: This is not the actual content height, but rather an estimate. In reality
+            //       you would want to do some calculations to keep this up to date and as close to
+            //       the real value as possible, but this suffices for the sake of the example. Try
+            //       playing around with the value to see how it affects the scrollbar. Try removing
+            //       it as well to see what that does.
+            .estimated_content_height = 800,
         },
         .rows = std.ArrayList(ModelRow).init(allocator),
     };
@@ -167,6 +173,8 @@ pub fn main() !void {
     try lipsum.append("    Etiam lacinia ornare mauris, ut lacinia elit sollicitudin non. Morbi cursus dictum enim, et vulputate mi sollicitudin vel. Fusce rutrum augue justo. Phasellus et mauris tincidunt erat lacinia bibendum sed eu orci. Sed nunc lectus, dignissim sit amet ultricies sit amet, efficitur eu urna. Fusce feugiat malesuada ipsum nec congue. Praesent ultrices metus eu pulvinar laoreet. Maecenas pellentesque, metus ac lobortis rhoncus, ligula eros consequat urna, eget dictum lectus sem ut orci. Donec lobortis, lacus sed bibendum auctor, odio turpis suscipit odio, vitae feugiat leo metus ac lectus. Curabitur sed sem arcu.");
     try lipsum.append("    Mauris nisi tortor, auctor venenatis turpis a, finibus condimentum lectus. Donec id velit odio. Curabitur ac varius lorem. Nam cursus quam in velit gravida, in bibendum purus fermentum. Sed non rutrum dui, nec ultrices ligula. Integer lacinia blandit nisl non sollicitudin. Praesent nec malesuada eros, sit amet tincidunt nunc.");
 
+    // Try playing around with the amount of items in the scroll view to see how the scrollbar
+    // reacts.
     for (0..10) |i| {
         for (lipsum.items, 0..) |paragraph, j| {
             const number = i * 10 + j;

--- a/examples/scroll.zig
+++ b/examples/scroll.zig
@@ -76,6 +76,14 @@ const Model = struct {
                     ctx.quit = true;
                     return;
                 }
+                if (key.matches(vaxis.Key.tab, .{})) {
+                    self.scroll_view.draw_cursor = !self.scroll_view.draw_cursor;
+                    return ctx.consumeAndRedraw();
+                }
+                if (key.matches(vaxis.Key.tab, .{ .shift = true })) {
+                    self.scroll_view.draw_scrollbars = !self.scroll_view.draw_scrollbars;
+                    return ctx.consumeAndRedraw();
+                }
                 return self.scroll_view.handleEvent(ctx, event);
             },
             else => {},

--- a/src/vxfw/ScrollBars.zig
+++ b/src/vxfw/ScrollBars.zig
@@ -51,7 +51,7 @@ horizontal_scrollbar_drag_thumb: vaxis.Cell = .{
 },
 
 /// You should not change this variable, treat it as private to the implementation. Used to track
-/// the size of the widget can locate scroll bars for mouse interaction.
+/// the size of the widget so we can locate scroll bars for mouse interaction.
 last_frame_size: vxfw.Size = .{ .width = 0, .height = 0 },
 /// You should not change this variable, treat it as private to the implementation. Used to track
 /// the position of the mouse relative to the scroll thumb for mouse interaction.

--- a/src/vxfw/ScrollBars.zig
+++ b/src/vxfw/ScrollBars.zig
@@ -90,7 +90,10 @@ pub fn draw(self: *ScrollBars, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surfa
 
     // 4. Draw the vertical scroll bar.
 
-    if (self.draw_vertical_scrollbar) {
+    if (self.draw_vertical_scrollbar) vertical: {
+        // If we can't scroll, then there's no need to draw the scroll bar.
+        if (self.scroll_view.scroll.top == 0 and !self.scroll_view.scroll.has_more) break :vertical;
+
         // To draw the vertical scrollbar we need to know how big the scroll bar thumb should be.
         // If we've been provided with an estimated height we use that to figure out how big the
         // thumb should be, otherwise we estimate the size based on how many of the children were

--- a/src/vxfw/ScrollBars.zig
+++ b/src/vxfw/ScrollBars.zig
@@ -1,0 +1,204 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+const vxfw = @import("vxfw.zig");
+
+const Allocator = std.mem.Allocator;
+
+const ScrollBars = @This();
+
+const vertical_scrollbar_thumb: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } };
+const horizontal_scrollbar_thumb: vaxis.Cell = .{ .char = .{ .grapheme = "▃", .width = 1 } };
+
+/// The ScrollBars widget must contain a ScrollView widget. The scroll bars drawn will be for the
+/// scroll view contained in the ScrollBars widget.
+scroll_view: vxfw.ScrollView,
+/// If `true` a horizontal scroll bar will be drawn. Set to `false` to hide the horizontal scroll
+/// bar. Defaults to `true`.
+draw_horizontal_scrollbar: bool = true,
+/// If `true` a vertical scroll bar will be drawn. Set to `false` to hide the vertical scroll bar.
+/// Defaults to `true`.
+draw_vertical_scrollbar: bool = true,
+/// The estimated height of all the content in the ScrollView. When provided this height will be
+/// used to calculate the size of the scrollbar's thumb. If this is not provided the widget will
+/// make a best effort estimate of the size of the thumb using the number of elements rendered at
+/// any given time. This will cause inconsistent thumb sizes - and possibly inconsistent
+/// positioning - if different elements in the ScrollView have different heights. For the best user
+/// experience, providing this estimate is strongly recommended.
+///
+/// Note that this doesn't necessarily have to be an accurate estimate and the tolerance for larger
+/// views is quite forgiving, especially if you overshoot the estimate.
+estimated_content_height: ?u32 = null,
+
+pub fn widget(self: *const ScrollBars) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *ScrollBars = @ptrCast(@alignCast(ptr));
+    return self.handleEvent(ctx, event);
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *ScrollBars = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn handleEvent(_: *ScrollBars, _: *vxfw.EventContext, _: vxfw.Event) anyerror!void {}
+
+pub fn draw(self: *ScrollBars, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    var children = std.ArrayList(vxfw.SubSurface).init(ctx.arena);
+
+    // 1. If we're not drawing the scrollbars we can just draw the ScrollView directly.
+
+    if (!self.draw_vertical_scrollbar and !self.draw_horizontal_scrollbar) {
+        try children.append(.{
+            .origin = .{ .row = 0, .col = 0 },
+            .surface = try self.scroll_view.draw(ctx),
+        });
+
+        return .{
+            .size = ctx.max.size(),
+            .widget = self.widget(),
+            .buffer = &.{},
+            .children = children.items,
+        };
+    }
+
+    // 2. Otherwise we can draw the scrollbars.
+
+    const max = ctx.max.size();
+
+    // 3. Draw the scroll view itself.
+
+    const scroll_view_surface = try self.scroll_view.draw(ctx.withConstraints(
+        ctx.min,
+        .{
+            // We make sure to make room for the scrollbars if required.
+            .width = max.width -| @intFromBool(self.draw_vertical_scrollbar),
+            .height = max.height -| @intFromBool(self.draw_horizontal_scrollbar),
+        },
+    ));
+
+    try children.append(.{
+        .origin = .{ .row = 0, .col = 0 },
+        .surface = scroll_view_surface,
+    });
+
+    // 4. Draw the vertical scroll bar.
+
+    if (self.draw_vertical_scrollbar) {
+        // To draw the vertical scrollbar we need to know how big the scroll bar thumb should be.
+        // If we've been provided with an estimated height we use that to figure out how big the
+        // thumb should be, otherwise we estimate the size based on how many of the children were
+        // actually drawn in the ScrollView.
+
+        const widget_height_f: f32 = @floatFromInt(scroll_view_surface.size.height);
+        const total_num_children_f: f32 = count: {
+            if (self.scroll_view.item_count) |c| break :count @floatFromInt(c);
+
+            switch (self.scroll_view.children) {
+                .slice => |slice| break :count @floatFromInt(slice.len),
+                .builder => |builder| {
+                    var counter: usize = 0;
+                    while (builder.itemAtIdx(counter, self.scroll_view.cursor)) |_|
+                        counter += 1;
+
+                    break :count @floatFromInt(counter);
+                },
+            }
+        };
+
+        const thumb_height: u16 = height: {
+            // If we know the height, we can use the height of the current view to determine the
+            // size of the thumb.
+            if (self.estimated_content_height) |h| {
+                const content_height_f: f32 = @floatFromInt(h);
+
+                const thumb_height_f = widget_height_f * widget_height_f / content_height_f;
+                break :height @intFromFloat(@max(thumb_height_f, 1));
+            }
+
+            // Otherwise we estimate the size of the thumb based on the number of child elements
+            // drawn in the scroll view, and the number of total child elements.
+
+            const num_children_rendered_f: f32 = @floatFromInt(scroll_view_surface.children.len);
+
+            const thumb_height_f = widget_height_f * num_children_rendered_f / total_num_children_f;
+            break :height @intFromFloat(@max(thumb_height_f, 1));
+        };
+
+        // We also need to know the position of the thumb in the scroll bar. To find that we use the
+        // index of the top-most child widget rendered in the ScrollView.
+
+        const thumb_top: u32 = if (self.scroll_view.scroll.top == 0)
+            0
+        else if (self.scroll_view.scroll.has_more) pos: {
+            const top_child_idx_f: f32 = @floatFromInt(self.scroll_view.scroll.top);
+            const thumb_top_f = widget_height_f * top_child_idx_f / total_num_children_f;
+
+            break :pos @intFromFloat(thumb_top_f);
+        } else max.height -| thumb_height;
+
+        // Once we know the thumb height and its position we can draw the scroll bar.
+
+        const scroll_bar = try vxfw.Surface.init(
+            ctx.arena,
+            self.widget(),
+            .{
+                .width = 1,
+                // We make sure to make room for the horizontal scroll bar if it's being drawn.
+                .height = max.height -| @intFromBool(self.draw_horizontal_scrollbar),
+            },
+        );
+
+        const thumb_end_row = thumb_top + thumb_height;
+        for (thumb_top..thumb_end_row) |row| {
+            scroll_bar.writeCell(
+                0,
+                @intCast(row),
+                vertical_scrollbar_thumb,
+            );
+        }
+
+        try children.append(.{
+            .origin = .{ .row = 0, .col = max.width -| 1 },
+            .surface = scroll_bar,
+        });
+    }
+
+    // 5. TODO: Draw the horizontal scroll bar.
+
+    // if (self.draw_horizontal_scrollbar) {
+    //     const scroll_bar = try vxfw.Surface.init(
+    //         ctx.arena,
+    //         self.widget(),
+    //         .{ .width = max.width, .height = 1 },
+    //     );
+    //     for (0..max.width / 2) |col| {
+    //         scroll_bar.writeCell(
+    //             @intCast(col),
+    //             0,
+    //             horizontal_scrollbar_thumb,
+    //         );
+    //     }
+    //     try children.append(.{
+    //         .origin = .{ .row = max.height -| 1, .col = 0 },
+    //         .surface = scroll_bar,
+    //     });
+    // }
+
+    return .{
+        .size = ctx.max.size(),
+        .widget = self.widget(),
+        .buffer = &.{},
+        .children = children.items,
+    };
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/ScrollBars.zig
+++ b/src/vxfw/ScrollBars.zig
@@ -117,8 +117,8 @@ pub fn handleCapture(self: *ScrollBars, ctx: *vxfw.EventContext, event: vxfw.Eve
                     mouse.button == .left and
                     self.is_dragging_vertical_thumb)
                 {
-                    // If we just let the scroll thumb go after dragging we need to make sure we redraw
-                    // so the right style is immediately applied to the thumb.
+                    // If we just let the scroll thumb go after dragging we need to make sure we
+                    // redraw so the right style is immediately applied to the thumb.
                     if (self.is_dragging_vertical_thumb) {
                         self.is_dragging_vertical_thumb = false;
                         ctx.redraw = true;
@@ -136,22 +136,22 @@ pub fn handleCapture(self: *ScrollBars, ctx: *vxfw.EventContext, event: vxfw.Eve
                         ctx.redraw = true;
                     }
 
-                    // No need to redraw yet, but we must consume the event so ending the drag action
-                    // doesn't trigger some other event handler.
+                    // No need to redraw yet, but we must consume the event so ending the drag
+                    // action doesn't trigger some other event handler.
                     return ctx.consumeEvent();
                 }
 
                 // Process dragging the vertical thumb.
                 if (mouse.type == .drag) {
-                    // Make sure we consume the event if we're currently dragging the mouse so other events
-                    // aren't sent in the mean time.
+                    // Make sure we consume the event if we're currently dragging the mouse so other
+                    // events aren't sent in the mean time.
                     ctx.consumeEvent();
 
                     // New scroll thumb position.
                     const new_thumb_top = mouse.row -| self.mouse_offset_into_thumb;
 
-                    // If the new thumb position is at the top we know we've scrolled to the top of the
-                    // scroll view.
+                    // If the new thumb position is at the top we know we've scrolled to the top of
+                    // the scroll view.
                     if (new_thumb_top == 0) {
                         self.scroll_view.scroll.top = 0;
                         return ctx.consumeAndRedraw();
@@ -189,8 +189,8 @@ pub fn handleCapture(self: *ScrollBars, ctx: *vxfw.EventContext, event: vxfw.Eve
                     mouse.button == .left and
                     self.is_dragging_horizontal_thumb)
                 {
-                    // If we just let the scroll thumb go after dragging we need to make sure we redraw
-                    // so the right style is immediately applied to the thumb.
+                    // If we just let the scroll thumb go after dragging we need to make sure we
+                    // redraw so the right style is immediately applied to the thumb.
                     if (self.is_dragging_horizontal_thumb) {
                         self.is_dragging_horizontal_thumb = false;
                         ctx.redraw = true;
@@ -208,8 +208,8 @@ pub fn handleCapture(self: *ScrollBars, ctx: *vxfw.EventContext, event: vxfw.Eve
                         ctx.redraw = true;
                     }
 
-                    // No need to redraw yet, but we must consume the event so ending the drag action
-                    // doesn't trigger some other event handler.
+                    // No need to redraw yet, but we must consume the event so ending the drag
+                    // action doesn't trigger some other event handler.
                     return ctx.consumeEvent();
                 }
 
@@ -275,7 +275,9 @@ pub fn handleEvent(self: *ScrollBars, ctx: *vxfw.EventContext, event: vxfw.Event
 
             if (did_start_dragging_horizontal_thumb) {
                 self.is_dragging_horizontal_thumb = true;
-                self.mouse_offset_into_thumb = @intCast(mouse.col -| self.horizontal_thumb_start_col);
+                self.mouse_offset_into_thumb = @intCast(
+                    mouse.col -| self.horizontal_thumb_start_col,
+                );
 
                 // No need to redraw yet, but we must consume the event.
                 return ctx.consumeEvent();

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -49,6 +49,7 @@ const Scroll = struct {
 };
 
 const cursor_indicator: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } };
+const scrollbar_thumb: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } };
 
 children: Source,
 cursor: u32 = 0,
@@ -560,7 +561,7 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
         // We need the scroll bar to be at least 1 row high so it's visible.
         const end_row = scroll_bar_top + @max(scroll_bar_height, 1);
         for (scroll_bar_top..end_row) |row| {
-            scroll_bar.writeCell(max_size.width - 1, @intCast(row), cursor_indicator);
+            scroll_bar.writeCell(max_size.width - 1, @intCast(row), scrollbar_thumb);
         }
 
         try children_with_scrollbar.append(.{

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -100,12 +100,20 @@ pub fn handleEvent(self: *ScrollView, ctx: *vxfw.EventContext, event: vxfw.Event
             if (key.matches(vaxis.Key.down, .{}) or
                 key.matches('n', .{ .ctrl = true }))
             {
-                return self.nextItem(ctx);
+                // If we're drawing the cursor, move it to the next item.
+                if (self.draw_cursor) return self.nextItem(ctx);
+
+                // Otherwise scroll the view down.
+                if (self.scroll.linesDown(1)) ctx.consumeAndRedraw();
             }
             if (key.matches(vaxis.Key.up, .{}) or
                 key.matches('p', .{ .ctrl = true }))
             {
-                return self.prevItem(ctx);
+                // If we're drawing the cursor, move it to the previous item.
+                if (self.draw_cursor) return self.prevItem(ctx);
+
+                // Otherwise scroll the view up.
+                if (self.scroll.linesUp(1)) ctx.consumeAndRedraw();
             }
             if (key.matches('d', .{ .ctrl = true })) {
                 const scroll_lines = @max(self.last_height / 2, 1);

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -579,7 +579,6 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
         // There's no need to draw the scrollbar if we're at the top and drew all the children.
         // In other words; if we can't scroll, we don't need the scrollbar.
         if (self.scroll.top != 0 or end != child_count or total_height > max_size.height) {
-            // We need the scroll bar to be at least 1 row high so it's visible.
             const scroll_bar_end = scroll_bar_top + scroll_bar_height;
             for (scroll_bar_top..scroll_bar_end) |row| {
                 scroll_bar.writeCell(max_size.width - 1, @intCast(row), scrollbar_thumb);

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -87,11 +87,11 @@ pub fn handleEvent(self: *ScrollView, ctx: *vxfw.EventContext, event: vxfw.Event
         .mouse => |mouse| {
             if (mouse.button == .wheel_up) {
                 if (self.scroll.linesUp(self.wheel_scroll))
-                    ctx.consumeAndRedraw();
+                    return ctx.consumeAndRedraw();
             }
             if (mouse.button == .wheel_down) {
                 if (self.scroll.linesDown(self.wheel_scroll))
-                    ctx.consumeAndRedraw();
+                    return ctx.consumeAndRedraw();
             }
         },
         .key_press => |key| {

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -53,7 +53,7 @@ const cursor_indicator: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1
 children: Source,
 cursor: u32 = 0,
 /// When true, the widget will draw a cursor next to the widget which has the cursor
-draw_cursor: bool = true,
+draw_cursor: bool = false,
 /// Lines to scroll for a mouse wheel
 wheel_scroll: u8 = 3,
 /// Set this if the exact item count is known.

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -98,6 +98,7 @@ pub fn handleEvent(self: *ScrollView, ctx: *vxfw.EventContext, event: vxfw.Event
         },
         .key_press => |key| {
             if (key.matches(vaxis.Key.down, .{}) or
+                key.matches('j', .{}) or
                 key.matches('n', .{ .ctrl = true }))
             {
                 // If we're drawing the cursor, move it to the next item.
@@ -107,6 +108,7 @@ pub fn handleEvent(self: *ScrollView, ctx: *vxfw.EventContext, event: vxfw.Event
                 if (self.scroll.linesDown(1)) ctx.consumeAndRedraw();
             }
             if (key.matches(vaxis.Key.up, .{}) or
+                key.matches('k', .{}) or
                 key.matches('p', .{ .ctrl = true }))
             {
                 // If we're drawing the cursor, move it to the previous item.

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -375,6 +375,13 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
         self.scroll.has_more = false;
     }
 
+    // If we've looped through all the items without hitting the end we check for one more item to
+    // see if we just drew the last item on the bottom of the screen. If we just drew the last item
+    // we can set `scroll.has_more` to false.
+    if (self.scroll.has_more) {
+        if (builder.itemAtIdx(i, self.cursor) == null) self.scroll.has_more = false;
+    }
+
     var total_height: usize = totalHeight(&child_list);
 
     // If we reached the bottom, don't have enough height to fill the screen, and have room to add
@@ -485,13 +492,6 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
             end = idx;
             break;
         }
-    }
-
-    // If we know the count, and the end index is at the last item we can be sure there is nothing
-    // more to draw, and thus we are at the end of the scroll view.
-    if (self.item_count) |count| {
-        std.log.debug("count: {d} ~ end: {d}", .{ count, end });
-        if (end == count - 1) self.scroll.has_more = false;
     }
 
     var children_with_scrollbar = std.ArrayList(vxfw.SubSurface).init(ctx.arena);

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -545,7 +545,9 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
 
         const widget_height_f: f32 = @floatFromInt(max_size.height);
         const total_height_f: f32 = @floatFromInt(estimated_total_height);
-        const scroll_top_f: f32 = @floatFromInt(self.scroll.top);
+        const scroll_top_f: f32 = @floatFromInt(
+            (self.scroll.top * total_height) / num_children_rendered,
+        );
 
         const scroll_bar_height_f: f32 = widget_height_f * (widget_height_f / total_height_f);
         const scroll_bar_height: u32 = @intFromFloat(scroll_bar_height_f);

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -96,10 +96,14 @@ pub fn handleEvent(self: *ScrollView, ctx: *vxfw.EventContext, event: vxfw.Event
             }
         },
         .key_press => |key| {
-            if (key.matches(vaxis.Key.down, .{})) {
+            if (key.matches(vaxis.Key.down, .{}) or
+                key.matches('n', .{ .ctrl = true }))
+            {
                 return self.nextItem(ctx);
             }
-            if (key.matches(vaxis.Key.up, .{})) {
+            if (key.matches(vaxis.Key.up, .{}) or
+                key.matches('p', .{ .ctrl = true }))
+            {
                 return self.prevItem(ctx);
             }
             if (key.matches(vaxis.Key.escape, .{})) {
@@ -712,7 +716,12 @@ test ScrollView {
     try std.testing.expectEqual(1, scroll_view.cursor);
 
     // Cursor down
-    try scroll_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.down } });
+    try scroll_widget.handleEvent(&ctx, .{
+        .key_press = .{
+            .codepoint = 'n',
+            .mods = .{ .ctrl = true },
+        },
+    });
     surface = try scroll_widget.draw(draw_ctx);
     // 0   abc
     // 1 |   def

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -497,17 +497,17 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
     var children_with_scrollbar = std.ArrayList(vxfw.SubSurface).init(ctx.arena);
 
     const num_children_rendered: usize = @max(end - start, 1);
-    const average_child_height: usize = max_size.height / num_children_rendered;
 
     const estimated_total_height = height: {
-        if (self.item_count) |count| break :height count * average_child_height;
+        if (self.item_count) |count|
+            break :height (count * total_height) / num_children_rendered;
 
         var child_count: usize = 0;
         while (builder.itemAtIdx(child_count, self.cursor)) |_| {
             child_count += 1;
         }
 
-        break :height child_count * average_child_height;
+        break :height (child_count * total_height) / num_children_rendered;
     };
 
     // We only show the scrollbar if the content height is larger than the widget height and
@@ -675,7 +675,7 @@ test ScrollView {
     try std.testing.expectEqual(3, surface.children.len);
 
     // Cursor down
-    try scroll_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    try scroll_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.down } });
     surface = try scroll_widget.draw(draw_ctx);
     // 0 | abc
     // 1 |   def
@@ -691,7 +691,7 @@ test ScrollView {
     try std.testing.expectEqual(1, scroll_view.cursor);
 
     // Cursor down
-    try scroll_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    try scroll_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.down } });
     surface = try scroll_widget.draw(draw_ctx);
     // 0   abc
     // 1 |   def
@@ -707,7 +707,7 @@ test ScrollView {
     try std.testing.expectEqual(2, scroll_view.cursor);
 
     // Cursor down
-    try scroll_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    try scroll_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.down } });
     surface = try scroll_widget.draw(draw_ctx);
     // 0   abc
     // 1     def
@@ -811,7 +811,7 @@ test "ScrollView: uneven scroll" {
     surface = try scroll_widget.draw(draw_ctx);
     try std.testing.expectEqual(1, scroll_view.scroll.top);
     try std.testing.expectEqual(0, scroll_view.scroll.offset);
-    try std.testing.expectEqual(4, surface.children.len);
+    try std.testing.expectEqual(5, surface.children.len);
 }
 
 test "refAllDecls" {

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -48,14 +48,14 @@ const Scroll = struct {
     }
 };
 
-const cursor_indicator: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } };
-const scrollbar_thumb: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } };
-
 children: Source,
 cursor: u32 = 0,
 last_height: u8 = 0,
 /// When true, the widget will draw a cursor next to the widget which has the cursor
 draw_cursor: bool = false,
+/// The cell that will be drawn to represent the scroll view's cursor. Replace this to customize the
+/// cursor indicator. Must have a 1 column width.
+cursor_indicator: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } },
 /// Lines to scroll for a mouse wheel
 wheel_scroll: u8 = 3,
 /// Set this if the exact item count is known.
@@ -435,7 +435,7 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
             sub,
         );
         for (0..cursor_surf.size.height) |row| {
-            cursor_surf.writeCell(0, @intCast(row), cursor_indicator);
+            cursor_surf.writeCell(0, @intCast(row), self.cursor_indicator);
         }
         child_list.items[cursored_idx] = .{
             .origin = .{ .col = 0, .row = child.origin.row },

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -1,0 +1,686 @@
+const std = @import("std");
+const vaxis = @import("../main.zig");
+
+const assert = std.debug.assert;
+
+const Allocator = std.mem.Allocator;
+
+const vxfw = @import("vxfw.zig");
+
+const ScrollView = @This();
+
+pub const Builder = struct {
+    userdata: *const anyopaque,
+    buildFn: *const fn (*const anyopaque, idx: usize, cursor: usize) ?vxfw.Widget,
+
+    inline fn itemAtIdx(self: Builder, idx: usize, cursor: usize) ?vxfw.Widget {
+        return self.buildFn(self.userdata, idx, cursor);
+    }
+};
+
+pub const Source = union(enum) {
+    slice: []const vxfw.Widget,
+    builder: Builder,
+};
+
+const Scroll = struct {
+    /// Index of the first fully-in-view widget
+    top: u32 = 0,
+    /// Line offset within the top widget.
+    offset: i17 = 0,
+    /// Pending scroll amount
+    pending_lines: i17 = 0,
+    /// If there is more room to scroll down
+    has_more: bool = true,
+    /// The cursor must be in the viewport
+    wants_cursor: bool = false,
+
+    pub fn linesDown(self: *Scroll, n: u8) bool {
+        if (!self.has_more) return false;
+        self.pending_lines += n;
+        return true;
+    }
+
+    pub fn linesUp(self: *Scroll, n: u8) bool {
+        if (self.top == 0 and self.offset == 0) return false;
+        self.pending_lines = -1 * @as(i17, @intCast(n));
+        return true;
+    }
+};
+
+const cursor_indicator: vaxis.Cell = .{ .char = .{ .grapheme = "▐", .width = 1 } };
+
+children: Source,
+cursor: u32 = 0,
+/// When true, the widget will draw a cursor next to the widget which has the cursor
+draw_cursor: bool = true,
+/// Lines to scroll for a mouse wheel
+wheel_scroll: u8 = 3,
+/// Set this if the exact item count is known.
+item_count: ?u32 = null,
+
+/// scroll position
+scroll: Scroll = .{},
+
+pub fn widget(self: *const ScrollView) vxfw.Widget {
+    return .{
+        .userdata = @constCast(self),
+        .eventHandler = typeErasedEventHandler,
+        .drawFn = typeErasedDrawFn,
+    };
+}
+
+fn typeErasedEventHandler(ptr: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    const self: *ScrollView = @ptrCast(@alignCast(ptr));
+    return self.handleEvent(ctx, event);
+}
+
+fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const self: *ScrollView = @ptrCast(@alignCast(ptr));
+    return self.draw(ctx);
+}
+
+pub fn handleEvent(self: *ScrollView, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
+    switch (event) {
+        .mouse => |mouse| {
+            if (mouse.button == .wheel_up) {
+                if (self.scroll.linesUp(self.wheel_scroll))
+                    ctx.consumeAndRedraw();
+            }
+            if (mouse.button == .wheel_down) {
+                if (self.scroll.linesDown(self.wheel_scroll))
+                    ctx.consumeAndRedraw();
+            }
+        },
+        .key_press => |key| {
+            if (key.matches(vaxis.Key.down, .{})) {
+                return self.nextItem(ctx);
+            }
+            if (key.matches(vaxis.Key.up, .{})) {
+                return self.prevItem(ctx);
+            }
+            if (key.matches(vaxis.Key.escape, .{})) {
+                self.ensureScroll();
+                return ctx.consumeAndRedraw();
+            }
+        },
+        else => {},
+    }
+}
+
+pub fn draw(self: *ScrollView, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    std.debug.assert(ctx.max.width != null);
+    std.debug.assert(ctx.max.height != null);
+    switch (self.children) {
+        .slice => |slice| {
+            self.item_count = @intCast(slice.len);
+            const builder: SliceBuilder = .{ .slice = slice };
+            return self.drawBuilder(ctx, .{ .userdata = &builder, .buildFn = SliceBuilder.build });
+        },
+        .builder => |b| return self.drawBuilder(ctx, b),
+    }
+}
+
+pub fn nextItem(self: *ScrollView, ctx: *vxfw.EventContext) void {
+    // If we have a count, we can handle this directly
+    if (self.item_count) |count| {
+        if (self.cursor >= count - 1) {
+            return ctx.consumeEvent();
+        }
+        self.cursor += 1;
+    } else {
+        switch (self.children) {
+            .slice => |slice| {
+                self.item_count = @intCast(slice.len);
+                // If we are already at the end, don't do anything
+                if (self.cursor == slice.len - 1) {
+                    return ctx.consumeEvent();
+                }
+                // Advance the cursor
+                self.cursor += 1;
+            },
+            .builder => |builder| {
+                // Save our current state
+                const prev = self.cursor;
+                // Advance the cursor
+                self.cursor += 1;
+                // Check the bounds, reversing until we get the last item
+                while (builder.itemAtIdx(self.cursor, self.cursor) == null) {
+                    self.cursor -|= 1;
+                }
+                // If we didn't change state, we don't redraw
+                if (self.cursor == prev) {
+                    return ctx.consumeEvent();
+                }
+            },
+        }
+    }
+    // Reset scroll
+    self.ensureScroll();
+    ctx.consumeAndRedraw();
+}
+
+pub fn prevItem(self: *ScrollView, ctx: *vxfw.EventContext) void {
+    if (self.cursor == 0) {
+        return ctx.consumeEvent();
+    }
+
+    if (self.item_count) |count| {
+        // If for some reason our count changed, we handle it here
+        self.cursor = @min(self.cursor - 1, count - 1);
+    } else {
+        switch (self.children) {
+            .slice => |slice| {
+                self.item_count = @intCast(slice.len);
+                self.cursor = @min(self.cursor - 1, slice.len - 1);
+            },
+            .builder => |builder| {
+                // Save our current state
+                const prev = self.cursor;
+                // Decrement the cursor
+                self.cursor -= 1;
+                // Check the bounds, reversing until we get the last item
+                while (builder.itemAtIdx(self.cursor, self.cursor) == null) {
+                    self.cursor -|= 1;
+                }
+                // If we didn't change state, we don't redraw
+                if (self.cursor == prev) {
+                    return ctx.consumeEvent();
+                }
+            },
+        }
+    }
+
+    // Reset scroll
+    self.ensureScroll();
+    return ctx.consumeAndRedraw();
+}
+
+// Only call when cursor state has changed, or we want to ensure the cursored item is in view
+pub fn ensureScroll(self: *ScrollView) void {
+    if (self.cursor <= self.scroll.top) {
+        self.scroll.top = @intCast(self.cursor);
+        self.scroll.offset = 0;
+    } else {
+        self.scroll.wants_cursor = true;
+    }
+}
+
+/// Inserts children until add_height is < 0
+fn insertChildren(
+    self: *ScrollView,
+    ctx: vxfw.DrawContext,
+    builder: Builder,
+    child_list: *std.ArrayList(vxfw.SubSurface),
+    add_height: i17,
+) Allocator.Error!void {
+    assert(self.scroll.top > 0);
+    self.scroll.top -= 1;
+    var upheight = add_height;
+    while (self.scroll.top >= 0) : (self.scroll.top -= 1) {
+        // Get the child
+        const child = builder.itemAtIdx(self.scroll.top, self.cursor) orelse break;
+
+        const child_offset: u16 = if (self.draw_cursor) 2 else 0;
+        const max_size = ctx.max.size();
+
+        // Set up constraints. We let the child be the entire height if it wants
+        const child_ctx = ctx.withConstraints(
+            .{ .width = max_size.width - child_offset, .height = 0 },
+            .{ .width = max_size.width - child_offset, .height = null },
+        );
+
+        // Draw the child
+        const surf = try child.draw(child_ctx);
+
+        // Accumulate the height. Traversing backward so do this before setting origin
+        upheight -= surf.size.height;
+
+        // Insert the child to the beginning of the list
+        try child_list.insert(0, .{
+            .origin = .{ .col = if (self.draw_cursor) 2 else 0, .row = upheight },
+            .surface = surf,
+            .z_index = 0,
+        });
+
+        // Break if we went past the top edge, or are the top item
+        if (upheight <= 0 or self.scroll.top == 0) break;
+    }
+
+    // Our new offset is the "upheight"
+    self.scroll.offset = upheight;
+
+    // Reset origins if we overshot and put the top item too low
+    if (self.scroll.top == 0 and upheight > 0) {
+        self.scroll.offset = 0;
+        var row: i17 = 0;
+        for (child_list.items) |*child| {
+            child.origin.row = row;
+            row += child.surface.size.height;
+        }
+    }
+    // Our new offset is the "upheight"
+    self.scroll.offset = upheight;
+}
+
+fn totalHeight(list: *const std.ArrayList(vxfw.SubSurface)) usize {
+    var result: usize = 0;
+    for (list.items) |child| {
+        result += child.surface.size.height;
+    }
+    return result;
+}
+
+fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Allocator.Error!vxfw.Surface {
+    defer self.scroll.wants_cursor = false;
+
+    // Get the size. asserts neither constraint is null
+    const max_size = ctx.max.size();
+    // Set up surface.
+    var surface: vxfw.Surface = .{
+        .size = max_size,
+        .widget = self.widget(),
+        .buffer = &.{},
+        .children = &.{},
+    };
+
+    // Set state
+    {
+        surface.focusable = true;
+        // Assume we have more. We only know we don't after drawing
+        self.scroll.has_more = true;
+    }
+
+    var child_list = std.ArrayList(vxfw.SubSurface).init(ctx.arena);
+
+    // Accumulated height tracks how much height we have drawn. It's initial state is
+    // (scroll.offset + scroll.pending_lines) lines _above_ the surface top edge.
+    // Example:
+    // 1. Scroll up 3 lines:
+    //      pending_lines = -3
+    //      offset = 0
+    //      accumulated_height = -(0 + -3) = 3;
+    //      Our first widget is placed at row 3, we will need to fill this in after the draw
+    // 2. Scroll up 3 lines, with an offset of 4
+    //      pending_lines = -3
+    //      offset = 4
+    //      accumulated_height = -(4 + -3) = -1;
+    //      Our first widget is placed at row -1
+    // 3. Scroll down 3 lines:
+    //      pending_lines = 3
+    //      offset = 0
+    //      accumulated_height = -(0 + 3) = -3;
+    //      Our first widget is placed at row -3. It's possible it consumes the entire widget. We
+    //      will check for this at the end and only include visible children
+    var accumulated_height: i17 = -(self.scroll.offset + self.scroll.pending_lines);
+
+    // We handled the pending scroll by assigning accumulated_height. Reset it's state
+    self.scroll.pending_lines = 0;
+
+    // Set the initial index for our downard loop. We do this here because we might modify
+    // scroll.top before we traverse downward
+    var i: usize = self.scroll.top;
+
+    // If we are on the first item, and we have an upward scroll that consumed our offset, eg
+    // accumulated_height > 0, we reset state here. We can't scroll up anymore so we set
+    // accumulated_height to 0.
+    if (accumulated_height > 0 and self.scroll.top == 0) {
+        self.scroll.offset = 0;
+        accumulated_height = 0;
+    }
+
+    // If we are offset downward, insert widgets to the front of the list before traversing downard
+    if (accumulated_height > 0) {
+        try self.insertChildren(ctx, builder, &child_list, accumulated_height);
+        const last_child = child_list.items[child_list.items.len - 1];
+        accumulated_height = last_child.origin.row + last_child.surface.size.height;
+    }
+
+    const child_offset: u16 = if (self.draw_cursor) 2 else 0;
+
+    while (builder.itemAtIdx(i, self.cursor)) |child| {
+        // Defer the increment
+        defer i += 1;
+
+        // Set up constraints. We let the child be the entire height if it wants
+        const child_ctx = ctx.withConstraints(
+            .{ .width = max_size.width - child_offset, .height = 0 },
+            .{ .width = max_size.width - child_offset, .height = null },
+        );
+
+        // Draw the child
+        var surf = try child.draw(child_ctx);
+        // We set the child to non-focusable so that we can manage where the keyevents go
+        surf.focusable = false;
+
+        // Add the child surface to our list. It's offset from parent is the accumulated height
+        try child_list.append(.{
+            .origin = .{ .col = child_offset, .row = accumulated_height },
+            .surface = surf,
+            .z_index = 0,
+        });
+
+        // Accumulate the height
+        accumulated_height += surf.size.height;
+
+        if (self.scroll.wants_cursor and i < self.cursor)
+            continue // continue if we want the cursor and haven't gotten there yet
+        else if (accumulated_height >= max_size.height)
+            break; // Break if we drew enough
+    } else {
+        // This branch runs if we ran out of items. Set our state accordingly
+        self.scroll.has_more = false;
+    }
+
+    var total_height: usize = totalHeight(&child_list);
+
+    // If we reached the bottom, don't have enough height to fill the screen, and have room to add
+    // more, then we add more until out of items or filled the space. This can happen on a resize
+    if (!self.scroll.has_more and total_height < max_size.height and self.scroll.top > 0) {
+        try self.insertChildren(ctx, builder, &child_list, @intCast(max_size.height - total_height));
+        // Set the new total height
+        total_height = totalHeight(&child_list);
+    }
+
+    if (self.draw_cursor and self.cursor >= self.scroll.top) blk: {
+        // The index of the cursored widget in our child_list
+        const cursored_idx: u32 = self.cursor - self.scroll.top;
+        // Nothing to draw if our cursor is below our viewport
+        if (cursored_idx >= child_list.items.len) break :blk;
+
+        const sub = try ctx.arena.alloc(vxfw.SubSurface, 1);
+        const child = child_list.items[cursored_idx];
+        sub[0] = .{
+            .origin = .{ .col = child_offset, .row = 0 },
+            .surface = child.surface,
+            .z_index = 0,
+        };
+        const cursor_surf = try vxfw.Surface.initWithChildren(
+            ctx.arena,
+            self.widget(),
+            .{ .width = child_offset, .height = child.surface.size.height },
+            sub,
+        );
+        for (0..cursor_surf.size.height) |row| {
+            cursor_surf.writeCell(0, @intCast(row), cursor_indicator);
+        }
+        child_list.items[cursored_idx] = .{
+            .origin = .{ .col = 0, .row = child.origin.row },
+            .surface = cursor_surf,
+            .z_index = 0,
+        };
+    }
+
+    // If we want the cursor, we check that the cursored widget is fully in view. If it is too
+    // large, we position it so that it is the top item with a 0 offset
+    if (self.scroll.wants_cursor) {
+        const cursored_idx: u32 = self.cursor - self.scroll.top;
+        const sub = child_list.items[cursored_idx];
+        // The bottom row of the cursored widget
+        const bottom = sub.origin.row + sub.surface.size.height;
+        if (bottom > max_size.height) {
+            // Adjust the origin by the difference
+            // anchor bottom
+            var origin: i17 = max_size.height;
+            var idx: usize = cursored_idx + 1;
+            while (idx > 0) : (idx -= 1) {
+                var child = child_list.items[idx - 1];
+                origin -= child.surface.size.height;
+                child.origin.row = origin;
+                child_list.items[idx - 1] = child;
+            }
+        } else if (sub.surface.size.height >= max_size.height) {
+            // TODO: handle when the child is larger than our height.
+            // We need to change the max constraint to be optional sizes so that we can support
+            // unbounded drawing in scrollable areas
+            self.scroll.top = self.cursor;
+            self.scroll.offset = 0;
+            child_list.deinit();
+            try child_list.append(.{
+                .origin = .{ .col = 0, .row = 0 },
+                .surface = sub.surface,
+                .z_index = 0,
+            });
+            total_height = sub.surface.size.height;
+        }
+    }
+
+    // If we reached the bottom, we need to reset origins
+    if (!self.scroll.has_more and total_height < max_size.height) {
+        // anchor top
+        assert(self.scroll.top == 0);
+        self.scroll.offset = 0;
+        var origin: i17 = 0;
+        for (0..child_list.items.len) |idx| {
+            var child = child_list.items[idx];
+            child.origin.row = origin;
+            origin += child.surface.size.height;
+            child_list.items[idx] = child;
+        }
+    } else if (!self.scroll.has_more) {
+        // anchor bottom
+        var origin: i17 = max_size.height;
+        var idx: usize = child_list.items.len;
+        while (idx > 0) : (idx -= 1) {
+            var child = child_list.items[idx - 1];
+            origin -= child.surface.size.height;
+            child.origin.row = origin;
+            child_list.items[idx - 1] = child;
+        }
+    }
+
+    var start: usize = 0;
+    var end: usize = child_list.items.len;
+
+    for (child_list.items, 0..) |child, idx| {
+        if (child.origin.row <= 0 and child.origin.row + child.surface.size.height > 0) {
+            start = idx;
+            self.scroll.offset = -child.origin.row;
+            self.scroll.top += @intCast(idx);
+        }
+        if (child.origin.row > max_size.height) {
+            end = idx;
+            break;
+        }
+    }
+
+    surface.children = child_list.items[start..end];
+    return surface;
+}
+
+const SliceBuilder = struct {
+    slice: []const vxfw.Widget,
+
+    fn build(ptr: *const anyopaque, idx: usize, _: usize) ?vxfw.Widget {
+        const self: *const SliceBuilder = @ptrCast(@alignCast(ptr));
+        if (idx >= self.slice.len) return null;
+        return self.slice[idx];
+    }
+};
+
+test ScrollView {
+    // Create child widgets
+    const Text = @import("Text.zig");
+    const abc: Text = .{ .text = "abc\n  def\n  ghi" };
+    const def: Text = .{ .text = "def" };
+    const ghi: Text = .{ .text = "ghi" };
+    const jklmno: Text = .{ .text = "jkl\n mno" };
+    // 0 |*abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 | def
+    // 4   ghi
+    // 5   jkl
+    // 6     mno
+
+    // Create the list view
+    const scroll_view: ScrollView = .{
+        .wheel_scroll = 1, // Set wheel scroll to one
+        .children = .{ .slice = &.{
+            abc.widget(),
+            def.widget(),
+            ghi.widget(),
+            jklmno.widget(),
+        } },
+    };
+
+    // Boiler plate draw context
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const ucd = try vaxis.Unicode.init(arena.allocator());
+    vxfw.DrawContext.init(&ucd, .unicode);
+
+    const list_widget = scroll_view
+        .widget();
+    const draw_ctx: vxfw.DrawContext = .{
+        .arena = arena.allocator(),
+        .min = .{},
+        .max = .{ .width = 16, .height = 4 },
+    };
+
+    var surface = try list_widget.draw(draw_ctx);
+    // ScrollView expands to max height and max width
+    try std.testing.expectEqual(4, surface.size.height);
+    try std.testing.expectEqual(16, surface.size.width);
+    // We have 2 children, because only visible children appear as a surface
+    try std.testing.expectEqual(2, surface.children.len);
+
+    var mouse_event: vaxis.Mouse = .{
+        .col = 0,
+        .row = 0,
+        .button = .wheel_up,
+        .mods = .{},
+        .type = .press,
+    };
+    // Event handlers need a context
+    var ctx: vxfw.EventContext = .{
+        .cmds = std.ArrayList(vxfw.Command).init(std.testing.allocator),
+    };
+    defer ctx.cmds.deinit();
+
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    // Wheel up doesn't adjust the scroll
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.offset);
+
+    // Send a wheel down
+    mouse_event.button = .wheel_down;
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    // We have to draw the widget for scrolls to take effect
+    surface = try list_widget.draw(draw_ctx);
+    // 0  *abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 | def
+    // 4 | ghi
+    // 5   jkl
+    // 6     mno
+    // We should have gone down 1 line, and not changed our top widget
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(1, scroll_view
+        .scroll.offset);
+    // One more widget has scrolled into view
+    try std.testing.expectEqual(3, surface.children.len);
+
+    // Scroll down two more lines
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    surface = try list_widget.draw(draw_ctx);
+    // 0  *abc
+    // 1     def
+    // 2     ghi
+    // 3 | def
+    // 4 | ghi
+    // 5 | jkl
+    // 6 |   mno
+    // We should have gone down 2 lines, which scrolls our top widget out of view
+    try std.testing.expectEqual(1, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+
+    // Scroll down again. We shouldn't advance anymore since we are at the bottom
+    try list_widget.handleEvent(&ctx, .{ .mouse = mouse_event });
+    surface = try list_widget.draw(draw_ctx);
+    try std.testing.expectEqual(1, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+
+    // Mouse wheel events don't change the cursor position. Let's press "escape" to reset the
+    // viewport and bring our cursor into view
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = vaxis.Key.escape } });
+    surface = try list_widget.draw(draw_ctx);
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.offset);
+    try std.testing.expectEqual(2, surface.children.len);
+
+    // Cursor down
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    surface = try list_widget.draw(draw_ctx);
+    // 0 | abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 |*def
+    // 4   ghi
+    // 5   jkl
+    // 6     mno
+    // Scroll doesn't change
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.offset);
+    try std.testing.expectEqual(2, surface.children.len);
+    try std.testing.expectEqual(1, scroll_view
+        .cursor);
+
+    // Cursor down
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    surface = try list_widget.draw(draw_ctx);
+    // 0   abc
+    // 1 |   def
+    // 2 |   ghi
+    // 3 | def
+    // 4 |*ghi
+    // 5   jkl
+    // 6     mno
+    // Scroll advances one row
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(1, scroll_view
+        .scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+    try std.testing.expectEqual(2, scroll_view
+        .cursor);
+
+    // Cursor down
+    try list_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = 'j' } });
+    surface = try list_widget.draw(draw_ctx);
+    // 0   abc
+    // 1     def
+    // 2     ghi
+    // 3 | def
+    // 4 | ghi
+    // 5 |*jkl
+    // 6 |   mno
+    // We are cursored onto the last item. The entire last item comes into view, effectively
+    // advancing the scroll by 2
+    try std.testing.expectEqual(1, scroll_view
+        .scroll.top);
+    try std.testing.expectEqual(0, scroll_view
+        .scroll.offset);
+    try std.testing.expectEqual(3, surface.children.len);
+    try std.testing.expectEqual(3, scroll_view
+        .cursor);
+}
+
+test "refAllDecls" {
+    std.testing.refAllDecls(@This());
+}

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -58,8 +58,8 @@ draw_cursor: bool = false,
 wheel_scroll: u8 = 3,
 /// Set this if the exact item count is known.
 item_count: ?u32 = null,
-/// When true, the widget will draw horizontal and vertical scrollbars on the right and bottom
-/// sides of the contained widget.
+/// When true, the widget will draw a vertical scrollbar on the right side of the contained widget.
+/// Eventually this will be used as an indicator for a horizontal scrollbar as well.
 draw_scrollbars: bool = true,
 
 /// scroll position

--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -525,12 +525,12 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
         const scroll_bar_height: u32 = @intFromFloat(scroll_bar_height_f);
 
         const scroll_bar_top_f: f32 = widget_height_f * (scroll_top_f / total_height_f);
-        const scroll_bar_top: u32 = if (self.scroll.has_more)
+        const scroll_bar_top: u32 = if (self.scroll.top == 0)
+            0 // At the top.
+        else if (self.scroll.has_more)
             @intFromFloat(scroll_bar_top_f)
-        else if (self.scroll.top == 0)
-            0
         else
-            max_size.height - scroll_bar_height;
+            max_size.height - scroll_bar_height; // At the bottom.
 
         // We need the scroll bar to be at least 1 row high so it's visible.
         const end_row = scroll_bar_top + @max(scroll_bar_height, 1);

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -19,6 +19,7 @@ pub const FlexRow = @import("FlexRow.zig");
 pub const ListView = @import("ListView.zig");
 pub const Padding = @import("Padding.zig");
 pub const RichText = @import("RichText.zig");
+pub const ScrollView = @import("ScrollView.zig");
 pub const SizedBox = @import("SizedBox.zig");
 pub const SplitView = @import("SplitView.zig");
 pub const Spinner = @import("Spinner.zig");

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -20,6 +20,7 @@ pub const ListView = @import("ListView.zig");
 pub const Padding = @import("Padding.zig");
 pub const RichText = @import("RichText.zig");
 pub const ScrollView = @import("ScrollView.zig");
+pub const ScrollBars = @import("ScrollBars.zig");
 pub const SizedBox = @import("SizedBox.zig");
 pub const SplitView = @import("SplitView.zig");
 pub const Spinner = @import("Spinner.zig");


### PR DESCRIPTION
> [!NOTE]
> I think this PR should supersede #144, since the implementation is cleaner, and it's easier to opt out of showing the scroll bars.

## Description

Adds a `ScrollView` widget to `vxfw` that allows for scrollable content, and a `ScrollBars` widget to render scroll bars that indicate the current position in the scrollable content. The `ScrollBars` widget must wrap the `ScrollView` widget. This is the same [approach taken by Flutter](https://api.flutter.dev/flutter/material/Scrollbar-class.html) for their scrollable components.

To estimate the size of the scrollbar thumb in the `ScrollBars` widget we use the number of children in the scroll view and how many were just drawn. If `estimated_content_height` is provided we use that instead for a more consistent experience. The documentation strongly recommends providing this.

### Known issues

* If the last element drawn is more than one line and you're at the bottom of the view, scrolling up one line (e.g. with <kbd>C-p</kbd>) won't work. I think the [anchoring functionality](https://github.com/reykjalin/libvaxis/blob/4cdbeba8c90ba603e4245aa9b5ed260e5f28e985/src/vxfw/ScrollView.zig#L507-L515) is causing this issue, and I'm not sure how to fix it.

### Limitations

* Currently only supports a vertical scrollbar, and vertical scrolling.
* Due to the way the scrollbar thumb size is estimated it may act wonky, e.g. the size may change as you scroll. Provide `estimated_content_height` to prevent that.

### Recording


https://github.com/user-attachments/assets/401870f3-a198-4160-bed9-73027bc48b2f



### Usage

See `examples/scroll.zig` for details, but here's a quick overview:

```zig
// Without scroll bars.
const scroll_view = try allocator.create(vxfw.ScrollView);
scroll_view.* = .{
    .children = .{
        .builder = .{
            .userdata = <parent_struct>,
            .buildFn = <parent_struct>.widgetBuilder,
        },
    },
};

try scroll_view.draw(draw_ctx);

// With scroll bars.

const scroll_bars = try allocator.create(vxfw.ScrollBars);
scroll_bars.* = .{
    .scroll_view = scroll_view,
};
```

### Options

**ScrollView:**

| Option | Effect |
|---:|:---|
| `scroll_view.draw_cursor` | set to `true` to draw a cursor indicating the currently active item, `false` to hide it.
| `scroll_view.item_count` | set to number of children to make it so the scroll view doesn't have to count them manually every time the scrollbar is drawn.
| `scroll_view.wheel_scroll` | set how much scrolling happens for each scroll of a mouse wheel.


**ScrollBars:**

| Option | Effect |
|---:|:---|
| `scroll_bars.estimated_content_height` | set this to the size of content in the scroll view - or a value close to it - to make the scrollbar thumb size more accurate.
| `scroll_bars.draw_vertical_scrollbar` | set to `true` to draw the vertical scrollbar, `false` to hide it.
| `scroll_bars.draw_horizontal_scrollbar` | set to `true` to draw the horizontal scrollbar, `false` to hide it.

## Testing instructions

Run `zig build example -Dexample=scroll` and play with the scroll example to see what the scrollbar looks like and how it behaves.

**Keybindings in example:**

| Keybinding | Effect |
|---:|:---|
|<kbd>C-c</kbd> | exit |
| <kbd>C-w</kbd> | Toggle line wrapping.
| <kbd>C-e</kbd> | Toggle content height estimate.
| <kbd>tab</kbd> | Toggle view cursor.
| <kbd>S-tab</kbd> | Toggle scrollbars.
| <kbd>C-v</kbd> | Toggle vertical scroll bar.
| <kbd>C-h</kbd> | Toggle horizontal scroll bar. Currently has no effect since horizontal scroll bars are not supported yet.
| <kbd>&darr;</kbd>/<kbd>C-n</kbd>/<kbd>j</kbd> | Scroll view down one line, or move the cursor down one element if the cursor is enabled.
| <kbd>&uarr;</kbd>/<kbd>C-p</kbd>/<kbd>k</kbd> | Scroll view up one line, or move the cursor up one element if the cursor is enabled.
| <kbd>C-d</kbd> | Scroll view down by half the current widget size.
| <kbd>C-u</kbd> | Scroll view up by half the current widget size.