### PR TITLE
Build fix

### DIFF
--- a/src/tty.zig
+++ b/src/tty.zig
@@ -788,4 +788,8 @@ pub const TestTty = struct {
     pub fn nextEvent(_: *Tty, _: *Parser, _: ?std.mem.Allocator) !Event {
         return error.SkipZigTest;
     }
+
+    pub fn resetSignalHandler() void {
+        return;
+    }
 };


### PR DESCRIPTION
I have no idea what resetSignalHandler should do in TestTty, but it at least fixes the compile error.