### PR TITLE
tty: assume posix systems support posix.empty_sigset

### DIFF
--- a/src/tty.zig
+++ b/src/tty.zig
@@ -59,9 +59,7 @@ pub const PosixTty = struct {
             .handler = .{ .handler = PosixTty.handleWinch },
             .mask = switch (builtin.os.tag) {
                 .macos => 0,
-                .linux => posix.empty_sigset,
-                .freebsd => posix.empty_sigset,
-                else => @compileError("os not supported"),
+                else => posix.empty_sigset,
             },
             .flags = 0,
         };
@@ -95,9 +93,7 @@ pub const PosixTty = struct {
             .handler = .{ .handler = posix.SIG.DFL },
             .mask = switch (builtin.os.tag) {
                 .macos => 0,
-                .linux => posix.empty_sigset,
-                .freebsd => posix.empty_sigset,
-                else => @compileError("os not supported"),
+                else => posix.empty_sigset,
             },
             .flags = 0,
         };


### PR DESCRIPTION
It should be pretty safe to assume that posix.empty_sigset is supported on most, if not all, posix systems. Individual OSes that need a different default value may add a case to the switch like macos.

This should open up support for most other posix systems.

closes #151