### PR TITLE
Expose loop namespace, fix compile errors with some of the widgets

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -305,15 +305,11 @@ release and is shown here merely as a proof of concept.
 ```zig
 const builtin = @import("builtin");
 const std = @import("std");
-const vaxis = @import("main.zig");
-const handleEventGeneric = @import("Loop.zig").handleEventGeneric;
+const vaxis = @import("vaxis");
+const handleEventGeneric = vaxis.loop.handleEventGeneric;
 const log = std.log.scoped(.vaxis_aio);
 
 const Yield = enum { no_state, took_event };
-
-pub fn Loop(T: type) type {
-    return LoopWithModules(T, @import("aio"), @import("coro"));
-}
 
 /// zig-aio based event loop
 /// <https://github.com/Cloudef/zig-aio>

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,7 +5,8 @@ const tty = @import("tty.zig");
 
 pub const Vaxis = @import("Vaxis.zig");
 
-pub const Loop = @import("Loop.zig").Loop;
+pub const loop = @import("Loop.zig");
+pub const Loop = loop.Loop;
 
 pub const zigimg = @import("zigimg");
 

--- a/src/widgets/LineNumbers.zig
+++ b/src/widgets/LineNumbers.zig
@@ -35,7 +35,7 @@ pub fn draw(self: @This(), win: vaxis.Window, y_scroll: usize) void {
         const num_digits = numDigits(line);
         for (0..num_digits) |i| {
             const digit = extractDigit(line, i);
-            win.writeCell(win.width -| (i + 2), line -| (y_scroll +| 1), .{
+            win.writeCell(@intCast(win.width -| (i + 2)), @intCast(line -| (y_scroll +| 1)), .{
                 .char = .{
                     .width = 1,
                     .grapheme = digits[digit .. digit + 1],
@@ -45,7 +45,7 @@ pub fn draw(self: @This(), win: vaxis.Window, y_scroll: usize) void {
         }
         if (highlighted) {
             for (num_digits + 1..win.width) |i| {
-                win.writeCell(i, line -| (y_scroll +| 1), .{
+                win.writeCell(@intCast(i), @intCast(line -| (y_scroll +| 1)), .{
                     .style = if (highlighted) self.highlighted_style else self.style,
                 });
             }

--- a/src/widgets/ScrollView.zig
+++ b/src/widgets/ScrollView.zig
@@ -115,14 +115,14 @@ pub fn bounds(self: *@This(), parent: vaxis.Window) BoundingBox {
 pub fn writeCell(self: *@This(), parent: vaxis.Window, col: usize, row: usize, cell: vaxis.Cell) void {
     const b = self.bounds(parent);
     if (!b.inside(col, row)) return;
-    const win = parent.child(.{ .width = b.x2 - b.x1, .height = b.y2 - b.y1 });
-    win.writeCell(col -| self.scroll.x, row -| self.scroll.y, cell);
+    const win = parent.child(.{ .width = @intCast(b.x2 - b.x1), .height = @intCast(b.y2 - b.y1) });
+    win.writeCell(@intCast(col -| self.scroll.x), @intCast(row -| self.scroll.y), cell);
 }
 
 /// Use this function instead of `Window.readCell` to read the correct cell in scrolling context.
 pub fn readCell(self: *@This(), parent: vaxis.Window, col: usize, row: usize) ?vaxis.Cell {
     const b = self.bounds(parent);
     if (!b.inside(col, row)) return;
-    const win = parent.child(.{ .width = b.width, .height = b.height });
-    return win.readCell(col -| self.scroll.x, row -| self.scroll.y);
+    const win = parent.child(.{ .width = @intCast(b.x2 - b.x1), .height = @intCast(b.y2 - b.y1) });
+    return win.readCell(@intCast(col -| self.scroll.x), @intCast(row -| self.scroll.y));
 }

--- a/src/widgets/Scrollbar.zig
+++ b/src/widgets/Scrollbar.zig
@@ -29,5 +29,5 @@ pub fn draw(self: Scrollbar, win: vaxis.Window) void {
     const bar_top = self.top * win.height / self.total;
     var i: usize = 0;
     while (i < bar_height) : (i += 1)
-        win.writeCell(0, i + bar_top, .{ .char = self.character, .style = self.style });
+        win.writeCell(0, @intCast(i + bar_top), .{ .char = self.character, .style = self.style });
 }


### PR DESCRIPTION
The loop namespace is used by the zig-aio loop for the handleEventGeneric function.