### PR TITLE
caps!: implement explicit width extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Unix-likes.
 - Color Mode Updates (Mode 2031)
 - [In-Band Resize Reports](https://gist.github.com/rockorager/e695fb2924d36b2bcf1fff4a3704bd83) (Mode 2048)
 - Images ([kitty graphics protocol](https://sw.kovidgoyal.net/kitty/graphics-protocol/))
+- [Explicit Width](https://github.com/kovidgoyal/kitty/blob/master/docs/text-sizing-protocol.rst) (width modifiers only)
 
 ## Usage
 

--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -177,6 +177,18 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                     }
                 },
                 .key_press => |key| {
+                    // Check for a cursor position response for our explicity width query. This will
+                    // always be an F3 key with shift = true, and we must be looking for queries
+                    if (key.codepoint == vaxis.Key.f3 and
+                        key.mods.shift and
+                        !vx.queries_done.load(.unordered))
+                    {
+                        log.info("explicit width capability detected", .{});
+                        vx.caps.explicit_width = true;
+                        vx.caps.unicode = .unicode;
+                        vx.screen.width_method = .unicode;
+                        return;
+                    }
                     if (@hasField(Event, "key_press")) {
                         // HACK: yuck. there has to be a better way
                         var mut_key = key;
@@ -198,6 +210,7 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                 },
                 .cap_da1 => {
                     std.Thread.Futex.wake(&vx.query_futex, 10);
+                    vx.queries_done.store(true, .unordered);
                 },
                 .mouse => |mouse| {
                     if (@hasField(Event, "mouse")) {
@@ -220,6 +233,18 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
         else => {
             switch (event) {
                 .key_press => |key| {
+                    // Check for a cursor position response for our explicity width query. This will
+                    // always be an F3 key with shift = true, and we must be looking for queries
+                    if (key.codepoint == vaxis.Key.f3 and
+                        key.mods.shift and
+                        !vx.queries_done.load(.unordered))
+                    {
+                        log.info("explicit width capability detected", .{});
+                        vx.caps.explicit_width = true;
+                        vx.caps.unicode = .unicode;
+                        vx.screen.width_method = .unicode;
+                        return;
+                    }
                     if (@hasField(Event, "key_press")) {
                         // HACK: yuck. there has to be a better way
                         var mut_key = key;
@@ -311,6 +336,7 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                 },
                 .cap_da1 => {
                     std.Thread.Futex.wake(&vx.query_futex, 10);
+                    vx.queries_done.store(true, .unordered);
                 },
                 .winsize => |winsize| {
                     vx.state.in_band_resize = true;

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -11,6 +11,8 @@ pub const decrqm_color_scheme = "\x1b[?2031$p";
 pub const csi_u_query = "\x1b[?u";
 pub const kitty_graphics_query = "\x1b_Gi=1,a=q\x1b\\";
 pub const sixel_geometry_query = "\x1b[?2;1;0S";
+pub const cursor_position_request = "\x1b[6n";
+pub const explicit_width_query = "\x1b]66;w=1; \x1b\\";
 
 // mouse. We try for button motion and any motion. terminals will enable the
 // last one we tried (any motion). This was added because zellij doesn't
@@ -31,6 +33,7 @@ pub const sync_reset = "\x1b[?2026l";
 // unicode
 pub const unicode_set = "\x1b[?2027h";
 pub const unicode_reset = "\x1b[?2027l";
+pub const explicit_width = "\x1b]66;w={d};{s}\x1b\\";
 
 // bracketed paste
 pub const bp_set = "\x1b[?2004h";


### PR DESCRIPTION
Implement explicit width hint extension, developed by kitty. When
both explicit width and mode 2027 are available, we default to explicit
width. Custom event loop authors will need to update their loops to add
support for this by setting the new capability value.

For simplicity, we don't actually add a flag in the parser for checking
between a cursor position and an F3 key. Instead, we send the cursor
home, then do an explicit width command, *then* check the cursor
position. If the cursor has moved - meaning the extension is supported -
we will see an F3 key with the shift modifier. The response will be
something like `\x1b[1;2R` which we parse as a shift+F3. But in the
loop, we check the flag if we have sent queries and handle this specific
event differently.

Reference: https://github.com/kovidgoyal/kitty/issues/8226
