### PR TITLE
feat: implement scaled text

### DIFF
--- a/examples/main.zig
+++ b/examples/main.zig
@@ -34,6 +34,8 @@ pub fn main() !void {
     var color_idx: u8 = 0;
     const msg = "Hello, world!";
 
+    var scale: u3 = 1;
+
     // The main event loop. Vaxis provides a thread safe, blocking, buffered
     // queue which can serve as the primary event queue for an application
     while (true) {
@@ -50,6 +52,16 @@ pub fn main() !void {
                 };
                 if (key.codepoint == 'c' and key.mods.ctrl) {
                     break;
+                }
+                if (key.matches('j', .{})) {
+                    if (vx.caps.scaled_text and scale > 1) {
+                        scale -= 1;
+                    }
+                }
+                if (key.matches('k', .{})) {
+                    if (vx.caps.scaled_text and scale < 7) {
+                        scale += 1;
+                    }
                 }
             },
             .winsize => |ws| {
@@ -86,8 +98,19 @@ pub fn main() !void {
                 .style = .{
                     .fg = .{ .index = color_idx },
                 },
+                .scale = .{
+                    .scale = scale,
+                },
             };
-            child.writeCell(@intCast(i), 0, cell);
+            const second_cell: Cell = .{
+                .char = .{ .grapheme = msg[i .. i + 1] },
+                .style = .{
+                    .fg = .{ .index = color_idx },
+                },
+            };
+            child.writeCell(@intCast(i * scale), 0, cell);
+            child.writeCell(@intCast(i), scale - 1, second_cell);
+            child.writeCell(@intCast(i), scale, second_cell);
         }
         // Render the screen
         try vx.render(tty.anyWriter());

--- a/src/Cell.zig
+++ b/src/Cell.zig
@@ -9,6 +9,7 @@ default: bool = false,
 /// Set to true if this cell is the last cell printed in a row before wrap. Vaxis will determine if
 /// it should rely on the terminal's autowrap feature which can help with primary screen resizes
 wrapped: bool = false,
+scale: Scale = .{},
 
 /// Segment is a contiguous run of text that has a constant style
 pub const Segment = struct {
@@ -40,6 +41,25 @@ pub const Hyperlink = struct {
     uri: []const u8 = "",
     /// ie "id=app-1234"
     params: []const u8 = "",
+};
+
+pub const Scale = packed struct {
+    scale: u3 = 1,
+    // The spec allows up to 15, but we limit to 7
+    numerator: u4 = 1,
+    // The spec allows up to 15, but we limit to 7
+    denominator: u4 = 1,
+    vertical_alignment: enum(u2) {
+        top = 0,
+        bottom = 1,
+        center = 2,
+    } = .top,
+
+    pub fn eql(self: Scale, other: Scale) bool {
+        const a_scale: u13 = @bitCast(self);
+        const b_scale: u13 = @bitCast(other);
+        return a_scale == b_scale;
+    }
 };
 
 pub const Style = struct {

--- a/src/InternalScreen.zig
+++ b/src/InternalScreen.zig
@@ -18,6 +18,12 @@ pub const InternalCell = struct {
     skipped: bool = false,
     default: bool = true,
 
+    // If we should skip rendering *this* round due to being printed over previously (from a scaled
+    // cell, for example)
+    skip: bool = false,
+
+    scale: Cell.Scale = .{},
+
     pub fn eql(self: InternalCell, cell: Cell) bool {
 
         // fastpath when both cells are default

--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -177,7 +177,7 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                     }
                 },
                 .key_press => |key| {
-                    // Check for a cursor position response for our explicity width query. This will
+                    // Check for a cursor position response for our explicit width query. This will
                     // always be an F3 key with shift = true, and we must be looking for queries
                     if (key.codepoint == vaxis.Key.f3 and
                         key.mods.shift and
@@ -187,6 +187,16 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                         vx.caps.explicit_width = true;
                         vx.caps.unicode = .unicode;
                         vx.screen.width_method = .unicode;
+                        return;
+                    }
+                    // Check for a cursor position response for our scaled text query. This will
+                    // always be an F3 key with alt = true, and we must be looking for queries
+                    if (key.codepoint == vaxis.Key.f3 and
+                        key.mods.alt and
+                        !vx.queries_done.load(.unordered))
+                    {
+                        log.info("scaled text capability detected", .{});
+                        vx.caps.scaled_text = true;
                         return;
                     }
                     if (@hasField(Event, "key_press")) {
@@ -243,6 +253,16 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                         vx.caps.explicit_width = true;
                         vx.caps.unicode = .unicode;
                         vx.screen.width_method = .unicode;
+                        return;
+                    }
+                    // Check for a cursor position response for our scaled text query. This will
+                    // always be an F3 key with alt = true, and we must be looking for queries
+                    if (key.codepoint == vaxis.Key.f3 and
+                        key.mods.alt and
+                        !vx.queries_done.load(.unordered))
+                    {
+                        log.info("scaled text capability detected", .{});
+                        vx.caps.scaled_text = true;
                         return;
                     }
                     if (@hasField(Event, "key_press")) {

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -13,6 +13,7 @@ pub const kitty_graphics_query = "\x1b_Gi=1,a=q\x1b\\";
 pub const sixel_geometry_query = "\x1b[?2;1;0S";
 pub const cursor_position_request = "\x1b[6n";
 pub const explicit_width_query = "\x1b]66;w=1; \x1b\\";
+pub const scaled_text_query = "\x1b]66;s=2; \x1b\\";
 
 // mouse. We try for button motion and any motion. terminals will enable the
 // last one we tried (any motion). This was added because zellij doesn't
@@ -34,6 +35,10 @@ pub const sync_reset = "\x1b[?2026l";
 pub const unicode_set = "\x1b[?2027h";
 pub const unicode_reset = "\x1b[?2027l";
 pub const explicit_width = "\x1b]66;w={d};{s}\x1b\\";
+
+// text sizing
+pub const scaled_text = "\x1b]66;s={d}:w={d};{s}\x1b\\";
+pub const scaled_text_with_fractions = "\x1b]66;s={d}:w={d}:n={d}:d={d}:v={d};{s}\x1b\\";
 
 // bracketed paste
 pub const bp_set = "\x1b[?2004h";


### PR DESCRIPTION
Implement the kitty scaled text extension. We do this by adding a Scale
struct to the core Cell structure. The scale struct defines the scale,
numerator, denominator, and vertical positioning. We also query
independently for scaled text vs explicit width text.

Users of scaled text must be very careful of how they model their cells,
as cells must be written ahead of time with knowledge of the
capabilities of the underlying terminal. Libvaxis does not move contents
of cells based on scale (ie 3 contiguous cells of scale=2 with contents
"abc" will not transform into what you think - the user of the library
must take car to put a, b, and c into appropriate cells. Libvaxis will
do the work to prevent overwriting the cell). Capability can be checked
in the vx.caps.scaled_text value.
