### PR TITLE
feature: add special keys to name map

### DIFF
--- a/src/Key.zig
+++ b/src/Key.zig
@@ -283,6 +283,11 @@ pub const name_map = blk: {
         .{ "comma", ',' },
 
         // special keys
+        .{ "tab", tab },
+        .{ "enter", enter },
+        .{ "escape", escape },
+        .{ "space", space },
+        .{ "backspace", backspace },
         .{ "insert", insert },
         .{ "delete", delete },
         .{ "left", left },


### PR DESCRIPTION
Is there any reason why `tab`, `enter`, `escape`, `space` and `backspace` are not in `name_map`?

I use `name_map` [here](https://github.com/freref/fancy-cat/blob/feature/command-mode/src/config/Config.zig#L143) to convert user-inputted keys from a config file to their ASCII values. Would be nice if they were included.