### PR TITLE
rename: freeImage to clearImage

### DIFF
--- a/examples/image.zig
+++ b/examples/image.zig
@@ -42,8 +42,8 @@ pub fn main() !void {
         // try vx.loadImage(alloc, tty.anyWriter(), .{ .path = "examples/zig.png" }),
         try vx.loadImage(alloc, tty.anyWriter(), .{ .path = "examples/vaxis.png" }),
     };
-    defer vx.freeImage(tty.anyWriter(), imgs[0].id);
-    defer vx.freeImage(tty.anyWriter(), imgs[1].id);
+    defer vx.clearImage(tty.anyWriter(), imgs[0].id);
+    defer vx.clearImage(tty.anyWriter(), imgs[1].id);
 
     var n: usize = 0;
 

--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -921,7 +921,7 @@ pub fn loadImage(
 }
 
 /// deletes an image from the terminal's memory
-pub fn freeImage(_: Vaxis, tty: AnyWriter, id: u32) void {
+pub fn clearImage(_: Vaxis, tty: AnyWriter, id: u32) void {
     tty.print("\x1b_Ga=d,d=I,i={d};\x1b\\", .{id}) catch |err| {
         log.err("couldn't delete image {d}: {}", .{ id, err });
         return;


### PR DESCRIPTION
Please consider renaming `freeImage` to `clearImage` (or something else)

`freeImage` implies memory deallocation, but the function actually sends a terminal command to delete an image. Reason I make this PR is because Claude keeps confusing it for memory deallocation. [Here](https://github.com/freref/fancy-cat/pull/12#issuecomment-2483379092) is someone else who also finds it confusing.