### PR TITLE
build: allow building split_view example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -34,6 +34,7 @@ pub fn build(b: *std.Build) void {
         image,
         main,
         scroll,
+        split_view,
         table,
         text_input,
         vaxis,


### PR DESCRIPTION
the example list in build.zig was missing the split_view example, making it not buildable