### PR TITLE
Small fixes

### DIFF
--- a/src/vxfw/Border.zig
+++ b/src/vxfw/Border.zig
@@ -49,21 +49,21 @@ pub fn draw(self: *const Border, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Sur
     // Draw the border
     const right_edge = size.width -| 1;
     const bottom_edge = size.height -| 1;
-    surf.writeCell(0, 0, .{ .char = .{ .grapheme = "╭", .width = 1 } });
-    surf.writeCell(right_edge, 0, .{ .char = .{ .grapheme = "╮", .width = 1 } });
-    surf.writeCell(right_edge, bottom_edge, .{ .char = .{ .grapheme = "╯", .width = 1 } });
-    surf.writeCell(0, bottom_edge, .{ .char = .{ .grapheme = "╰", .width = 1 } });
+    surf.writeCell(0, 0, .{ .char = .{ .grapheme = "╭", .width = 1 }, .style = self.style });
+    surf.writeCell(right_edge, 0, .{ .char = .{ .grapheme = "╮", .width = 1 }, .style = self.style });
+    surf.writeCell(right_edge, bottom_edge, .{ .char = .{ .grapheme = "╯", .width = 1 }, .style = self.style });
+    surf.writeCell(0, bottom_edge, .{ .char = .{ .grapheme = "╰", .width = 1 }, .style = self.style });
 
     var col: u16 = 1;
     while (col < right_edge) : (col += 1) {
-        surf.writeCell(col, 0, .{ .char = .{ .grapheme = "─", .width = 1 } });
-        surf.writeCell(col, bottom_edge, .{ .char = .{ .grapheme = "─", .width = 1 } });
+        surf.writeCell(col, 0, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = self.style });
+        surf.writeCell(col, bottom_edge, .{ .char = .{ .grapheme = "─", .width = 1 }, .style = self.style });
     }
 
     var row: u16 = 1;
     while (row < bottom_edge) : (row += 1) {
-        surf.writeCell(0, row, .{ .char = .{ .grapheme = "│", .width = 1 } });
-        surf.writeCell(right_edge, row, .{ .char = .{ .grapheme = "│", .width = 1 } });
+        surf.writeCell(0, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = self.style });
+        surf.writeCell(right_edge, row, .{ .char = .{ .grapheme = "│", .width = 1 }, .style = self.style });
     }
     return surf;
 }

--- a/src/vxfw/FlexColumn.zig
+++ b/src/vxfw/FlexColumn.zig
@@ -81,7 +81,7 @@ pub fn draw(self: *const FlexColumn, ctx: vxfw.DrawContext) Allocator.Error!vxfw
             .z_index = 0,
         });
         max_width = @max(max_width, surf.size.width);
-        second_pass_height += surf.size.height;
+        second_pass_height += child_height;
     }
 
     const size: vxfw.Size = .{ .width = max_width, .height = second_pass_height };

--- a/src/vxfw/FlexRow.zig
+++ b/src/vxfw/FlexRow.zig
@@ -80,7 +80,7 @@ pub fn draw(self: *const FlexRow, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Su
             .z_index = 0,
         });
         max_height = @max(max_height, surf.size.height);
-        second_pass_width += surf.size.width;
+        second_pass_width += child_width;
     }
     const size: vxfw.Size = .{ .width = second_pass_width, .height = max_height };
     return .{


### PR DESCRIPTION
* made flexbox and flexrow use the calculated width and height, since using the child surface one doesnt work with sizedbox, since its always at max its defined size.
* made border use the style defined in border.zig, so border styling works now