### PR TITLE
add workarounds mode with a fix for the conpty UL bug

### DIFF
--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -80,6 +80,10 @@ sgr: enum {
     legacy,
 } = .standard,
 
+/// Enable workarounds for escape sequence handling issues/bugs in terminals
+/// So far this just enables a UL escape sequence workaround for conpty
+enable_workarounds: bool = true,
+
 state: struct {
     /// if we are in the alt screen
     alt_screen: bool = false,
@@ -574,7 +578,9 @@ pub fn render(self: *Vaxis, tty: AnyWriter) !void {
                     }
                 },
                 .rgb => |rgb| {
-                    switch (self.sgr) {
+                    if (self.enable_workarounds)
+                        try tty.print(ctlseqs.ul_rgb_conpty, .{ rgb[0], rgb[1], rgb[2] })
+                    else switch (self.sgr) {
                         .standard => try tty.print(ctlseqs.ul_rgb, .{ rgb[0], rgb[1], rgb[2] }),
                         .legacy => try tty.print(ctlseqs.ul_rgb_legacy, .{ rgb[0], rgb[1], rgb[2] }),
                     }
@@ -1237,9 +1243,13 @@ pub fn prettyPrint(self: *Vaxis, tty: AnyWriter) !void {
                     }
                 },
                 .rgb => |rgb| {
-                    switch (self.sgr) {
+                    if (self.enable_workarounds)
+                        try tty.print(ctlseqs.ul_rgb_conpty, .{ rgb[0], rgb[1], rgb[2] })
+                    else switch (self.sgr) {
                         .standard => try tty.print(ctlseqs.ul_rgb, .{ rgb[0], rgb[1], rgb[2] }),
-                        .legacy => try tty.print(ctlseqs.ul_rgb_legacy, .{ rgb[0], rgb[1], rgb[2] }),
+                        .legacy => {
+                            try tty.print(ctlseqs.ul_rgb_legacy, .{ rgb[0], rgb[1], rgb[2] });
+                        },
                     }
                 },
             }

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -95,6 +95,7 @@ pub const ul_indexed_legacy = "\x1b[58;5;{d}m";
 pub const fg_rgb_legacy = "\x1b[38;2;{d};{d};{d}m";
 pub const bg_rgb_legacy = "\x1b[48;2;{d};{d};{d}m";
 pub const ul_rgb_legacy = "\x1b[58;2;{d};{d};{d}m";
+pub const ul_rgb_conpty = "\x1b[58:2::{d}:{d}:{d}m";
 
 // Underlines
 pub const ul_off = "\x1b[24m"; // NOTE: this could be \x1b[4:0m but is not as widely supported


### PR DESCRIPTION
conpty's grasp of ansi escape codes is a little shaky (at best). This PR adds a flag to libvaxis to enable conpty specific ansi sequence workarounds.

There is just one hack (so far), a version of `ul_rgb` (called `ul_rgb_conpty`) that contains an extra colon. Without the extra colon in `ul_rgb` conpty gets it's internal state really confused and fails to parse ansi sequences that follow this one causing chaos.