### PR TITLE
fix: add support for kitty mouse leave events

### DIFF
--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -289,6 +289,11 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                         return self.postEvent(.{ .mouse = vx.translateMouse(mouse) });
                     }
                 },
+                .mouse_leave => {
+                    if (@hasField(Event, "mouse_leave")) {
+                        return self.postEvent(.mouse_leave);
+                    }
+                },
                 .focus_in => {
                     if (@hasField(Event, "focus_in")) {
                         return self.postEvent(.focus_in);

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -25,6 +25,7 @@ const mouse_bits = struct {
     const shift: u8 = 0b00000100;
     const alt: u8 = 0b00001000;
     const ctrl: u8 = 0b00010000;
+    const leave: u16 = 0b100000000;
 };
 
 // the state of the parser
@@ -678,6 +679,9 @@ inline fn parseMouse(input: []const u8, full_input: []const u8) Result {
     } else {
         return null_event;
     }
+
+    if (button_mask & mouse_bits.leave > 0)
+        return .{ .event = .mouse_leave, .n = if (xterm) 6 else input.len };
 
     const button: Mouse.Button = @enumFromInt(button_mask & mouse_bits.buttons);
     const motion = button_mask & mouse_bits.motion > 0;

--- a/src/event.zig
+++ b/src/event.zig
@@ -8,6 +8,7 @@ pub const Event = union(enum) {
     key_press: Key,
     key_release: Key,
     mouse: Mouse,
+    mouse_leave,
     focus_in,
     focus_out,
     paste_start, // bracketed paste start


### PR DESCRIPTION
This prevents reporting kitty mouse leave events as spurious mouse clicks.