### PR TITLE
fixes to get the Terminal widget and the Flow Control editor working with zig-0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ pub fn main() !void {
     var vx = try vaxis.init(alloc, .{});
     // deinit takes an optional allocator. If your program is exiting, you can
     // choose to pass a null allocator to save some exit time.
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
 
     // The event loop requires an intrusive init. We create an instance with
@@ -317,7 +317,7 @@ pub fn main() !void {
     defer loop.stop();
 
     // Optionally enter the alternate screen
-    try vx.enterAltScreen(tty.anyWriter());
+    try vx.enterAltScreen(tty.writer());
 
     // We'll adjust the color index every keypress for the border
     var color_idx: u8 = 0;
@@ -329,7 +329,7 @@ pub fn main() !void {
 
     // Sends queries to terminal to detect certain features. This should always
     // be called after entering the alt screen, if you are using the alt screen
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
     while (true) {
         // nextEvent blocks until an event is in the queue
@@ -365,7 +365,7 @@ pub fn main() !void {
             // more than one byte will incur an allocation on the first render
             // after it is drawn. Thereafter, it will not allocate unless the
             // screen is resized
-            .winsize => |ws| try vx.resize(alloc, tty.anyWriter(), ws),
+            .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
             else => {},
         }
 
@@ -401,7 +401,7 @@ pub fn main() !void {
 
         // Render the screen. Using a buffered writer will offer much better
 	// performance, but is not required
-        try vx.render(tty.anyWriter());
+        try vx.render(tty.writer());
     }
 }
 ```

--- a/USAGE.md
+++ b/USAGE.md
@@ -247,7 +247,7 @@ pub fn TtyWatcher(comptime Userdata: type) type {
                         self.vx.caps.color_scheme_updates = true;
                     },
                     .cap_da1 => {
-                        self.vx.enableDetectedFeatures(self.tty.anyWriter()) catch |err| {
+                        self.vx.enableDetectedFeatures(self.tty.writer()) catch |err| {
                             log.err("couldn't enable features: {}", .{err});
                         };
                     },
@@ -328,7 +328,7 @@ pub fn LoopWithModules(T: type, aio: type, coro: type) type {
         }
 
         pub fn deinit(self: *@This(), vx: *vaxis.Vaxis, tty: *vaxis.Tty) void {
-            vx.deviceStatusReport(tty.anyWriter()) catch {};
+            vx.deviceStatusReport(tty.writer()) catch {};
             if (self.winsize_task) |task| task.cancel();
             if (self.reader_task) |task| task.cancel();
             self.source.deinit();

--- a/examples/cli.zig
+++ b/examples/cli.zig
@@ -19,7 +19,7 @@ pub fn main() !void {
     defer tty.deinit();
 
     var vx = try vaxis.init(alloc, .{});
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
     var loop: vaxis.Loop(Event) = .{ .tty = &tty, .vaxis = &vx };
     try loop.init();
@@ -27,7 +27,7 @@ pub fn main() !void {
     try loop.start();
     defer loop.stop();
 
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
     var text_input = TextInput.init(alloc, &vx.unicode);
     defer text_input.deinit();
@@ -75,7 +75,7 @@ pub fn main() !void {
                 }
             },
             .winsize => |ws| {
-                try vx.resize(alloc, tty.anyWriter(), ws);
+                try vx.resize(alloc, tty.writer(), ws);
             },
             else => {},
         }
@@ -96,7 +96,7 @@ pub fn main() !void {
                 _ = win.print(&seg, .{ .row_offset = @intCast(j + 1) });
             }
         }
-        try vx.render(tty.anyWriter());
+        try vx.render(tty.writer());
     }
 }
 

--- a/examples/image.zig
+++ b/examples/image.zig
@@ -23,7 +23,7 @@ pub fn main() !void {
     defer tty.deinit();
 
     var vx = try vaxis.init(alloc, .{});
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
     var loop: vaxis.Loop(Event) = .{ .tty = &tty, .vaxis = &vx };
     try loop.init();
@@ -31,21 +31,21 @@ pub fn main() !void {
     try loop.start();
     defer loop.stop();
 
-    try vx.enterAltScreen(tty.anyWriter());
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+    try vx.enterAltScreen(tty.writer());
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
     var read_buffer: [1024 * 1024]u8 = undefined; // 1MB buffer
     var img1 = try vaxis.zigimg.Image.fromFilePath(alloc, "examples/zig.png", &read_buffer);
     defer img1.deinit();
 
     const imgs = [_]vaxis.Image{
-        try vx.transmitImage(alloc, tty.anyWriter(), &img1, .rgba),
+        try vx.transmitImage(alloc, tty.writer(), &img1, .rgba),
         // var img1 = try vaxis.zigimg.Image.fromFilePath(alloc, "examples/zig.png");
-        // try vx.loadImage(alloc, tty.anyWriter(), .{ .path = "examples/zig.png" }),
-        try vx.loadImage(alloc, tty.anyWriter(), .{ .path = "examples/vaxis.png" }),
+        // try vx.loadImage(alloc, tty.writer(), .{ .path = "examples/zig.png" }),
+        try vx.loadImage(alloc, tty.writer(), .{ .path = "examples/vaxis.png" }),
     };
-    defer vx.freeImage(tty.anyWriter(), imgs[0].id);
-    defer vx.freeImage(tty.anyWriter(), imgs[1].id);
+    defer vx.freeImage(tty.writer(), imgs[0].id);
+    defer vx.freeImage(tty.writer(), imgs[1].id);
 
     var n: usize = 0;
 
@@ -64,7 +64,7 @@ pub fn main() !void {
                 else if (key.matches('k', .{}))
                     clip_y -|= 1;
             },
-            .winsize => |ws| try vx.resize(alloc, tty.anyWriter(), ws),
+            .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
         }
 
         n = (n + 1) % imgs.len;
@@ -78,6 +78,6 @@ pub fn main() !void {
             .y = clip_y,
         } });
 
-        try vx.render(tty.anyWriter());
+        try vx.render(tty.writer());
     }
 }

--- a/examples/main.zig
+++ b/examples/main.zig
@@ -19,7 +19,7 @@ pub fn main() !void {
     defer tty.deinit();
 
     var vx = try vaxis.init(alloc, .{});
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
     var loop: vaxis.Loop(Event) = .{ .tty = &tty, .vaxis = &vx };
     try loop.init();
@@ -28,8 +28,8 @@ pub fn main() !void {
     defer loop.stop();
 
     // Optionally enter the alternate screen
-    try vx.enterAltScreen(tty.anyWriter());
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+    try vx.enterAltScreen(tty.writer());
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
     // We'll adjust the color index every keypress
     var color_idx: u8 = 0;
@@ -66,7 +66,7 @@ pub fn main() !void {
                 }
             },
             .winsize => |ws| {
-                try vx.resize(alloc, tty.anyWriter(), ws);
+                try vx.resize(alloc, tty.writer(), ws);
             },
             else => {},
         }
@@ -114,7 +114,7 @@ pub fn main() !void {
             child.writeCell(@intCast(i), scale, second_cell);
         }
         // Render the screen
-        try vx.render(tty.anyWriter());
+        try vx.render(tty.writer());
     }
 }
 

--- a/examples/table.zig
+++ b/examples/table.zig
@@ -30,11 +30,11 @@ pub fn main() !void {
     var buffer: [1024]u8 = undefined;
     var tty = try vaxis.Tty.init(&buffer);
     defer tty.deinit();
-    const tty_writer = tty.anyWriter();
+    const tty_writer = tty.writer();
     var vx = try vaxis.init(alloc, .{
         .kitty_keyboard_flags = .{ .report_events = true },
     });
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
     var loop: vaxis.Loop(union(enum) {
         key_press: vaxis.Key,
@@ -44,8 +44,8 @@ pub fn main() !void {
     try loop.init();
     try loop.start();
     defer loop.stop();
-    try vx.enterAltScreen(tty.anyWriter());
-    try vx.queryTerminal(tty.anyWriter(), 250 * std.time.ns_per_ms);
+    try vx.enterAltScreen(tty.writer());
+    try vx.queryTerminal(tty.writer(), 250 * std.time.ns_per_ms);
 
     const logo =
         \\░█░█░█▀█░█░█░▀█▀░█▀▀░░░▀█▀░█▀█░█▀▄░█░░░█▀▀░
@@ -191,7 +191,7 @@ pub fn main() !void {
                 }
                 moving = false;
             },
-            .winsize => |ws| try vx.resize(alloc, tty.anyWriter(), ws),
+            .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
             else => {},
         }
 

--- a/examples/text_input.zig
+++ b/examples/text_input.zig
@@ -36,13 +36,13 @@ pub fn main() !void {
 
     // Use a buffered writer for better performance. There are a lot of writes
     // in the render loop and this can have a significant savings
-    const writer = tty.anyWriter();
+    const writer = tty.writer();
 
     // Initialize Vaxis
     var vx = try vaxis.init(alloc, .{
         .kitty_keyboard_flags = .{ .report_events = true },
     });
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
     var loop: vaxis.Loop(Event) = .{
         .vaxis = &vx,
@@ -71,7 +71,7 @@ pub fn main() !void {
     try writer.flush();
     // Sends queries to terminal to detect certain features. This should
     // _always_ be called, but is left to the application to decide when
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
     // The main event loop. Vaxis provides a thread safe, blocking, buffered
     // queue which can serve as the primary event queue for an application
@@ -92,12 +92,12 @@ pub fn main() !void {
                 } else if (key.matches('l', .{ .ctrl = true })) {
                     vx.queueRefresh();
                 } else if (key.matches('n', .{ .ctrl = true })) {
-                    try vx.notify(tty.anyWriter(), "vaxis", "hello from vaxis");
+                    try vx.notify(tty.writer(), "vaxis", "hello from vaxis");
                     loop.stop();
                     var child = std.process.Child.init(&.{"nvim"}, alloc);
                     _ = try child.spawnAndWait();
                     try loop.start();
-                    try vx.enterAltScreen(tty.anyWriter());
+                    try vx.enterAltScreen(tty.writer());
                     vx.queueRefresh();
                 } else if (key.matches(vaxis.Key.enter, .{}) or key.matches('j', .{ .ctrl = true })) {
                     text_input.clearAndFree();
@@ -121,7 +121,7 @@ pub fn main() !void {
             // more than one byte will incur an allocation on the first render
             // after it is drawn. Thereafter, it will not allocate unless the
             // screen is resized
-            .winsize => |ws| try vx.resize(alloc, tty.anyWriter(), ws),
+            .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
             else => {},
         }
 

--- a/examples/vaxis.zig
+++ b/examples/vaxis.zig
@@ -25,7 +25,7 @@ pub fn main() !void {
     defer tty.deinit();
 
     var vx = try vaxis.init(alloc, .{});
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
     var loop: vaxis.Loop(Event) = .{ .tty = &tty, .vaxis = &vx };
     try loop.init();
@@ -33,11 +33,11 @@ pub fn main() !void {
     try loop.start();
     defer loop.stop();
 
-    try vx.enterAltScreen(tty.anyWriter());
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+    try vx.enterAltScreen(tty.writer());
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
-    try vx.queryColor(tty.anyWriter(), .fg);
-    try vx.queryColor(tty.anyWriter(), .bg);
+    try vx.queryColor(tty.writer(), .fg);
+    try vx.queryColor(tty.writer(), .bg);
     var pct: u8 = 0;
     var dir: enum {
         up,
@@ -53,7 +53,7 @@ pub fn main() !void {
         switch (event) {
             .key_press => |key| if (key.matches('c', .{ .ctrl = true })) return,
             .winsize => |ws| {
-                try vx.resize(alloc, tty.anyWriter(), ws);
+                try vx.resize(alloc, tty.writer(), ws);
                 break;
             },
         }
@@ -63,7 +63,7 @@ pub fn main() !void {
         while (loop.tryEvent()) |event| {
             switch (event) {
                 .key_press => |key| if (key.matches('c', .{ .ctrl = true })) return,
-                .winsize => |ws| try vx.resize(alloc, tty.anyWriter(), ws),
+                .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
             }
         }
 
@@ -83,7 +83,7 @@ pub fn main() !void {
         // var bw = tty.bufferedWriter();
         // try vx.render(bw.writer().any());
         // try bw.flush();
-        try vx.render(tty.anyWriter());
+        try vx.render(tty.writer());
         std.Thread.sleep(16 * std.time.ns_per_ms);
         switch (dir) {
             .up => {

--- a/examples/view.zig
+++ b/examples/view.zig
@@ -48,13 +48,13 @@ pub fn main() !void {
     var tty = try vaxis.Tty.init(&buffer);
     defer tty.deinit();
 
-    const writer = tty.anyWriter();
+    const writer = tty.writer();
 
     // Initialize Vaxis
     var vx = try vaxis.init(alloc, .{
         .kitty_keyboard_flags = .{ .report_events = true },
     });
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
     var loop: vaxis.Loop(Event) = .{
         .vaxis = &vx,
         .tty = &tty,
@@ -64,7 +64,7 @@ pub fn main() !void {
     defer loop.stop();
     try vx.enterAltScreen(writer);
     try writer.flush();
-    try vx.queryTerminal(tty.anyWriter(), 20 * std.time.ns_per_s);
+    try vx.queryTerminal(tty.writer(), 20 * std.time.ns_per_s);
 
     // Initialize Views
     // - Large Map
@@ -128,7 +128,7 @@ pub fn main() !void {
                 // Mini View (Forced Width & Height Limits)
                 if (key.matches('m', .{})) use_mini_view = !use_mini_view;
             },
-            .winsize => |ws| try vx.resize(alloc, tty.anyWriter(), ws),
+            .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
         }
 
         const win = vx.window();

--- a/examples/vt.zig
+++ b/examples/vt.zig
@@ -23,7 +23,7 @@ pub fn main() !void {
     var buffer: [1024]u8 = undefined;
     var tty = try vaxis.Tty.init(&buffer);
     var vx = try vaxis.init(alloc, .{});
-    defer vx.deinit(alloc, tty.anyWriter());
+    defer vx.deinit(alloc, tty.writer());
 
     var loop: vaxis.Loop(Event) = .{ .tty = &tty, .vaxis = &vx };
     try loop.init();
@@ -33,8 +33,8 @@ pub fn main() !void {
 
     var buffered = tty.bufferedWriter();
 
-    try vx.enterAltScreen(tty.anyWriter());
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_s);
+    try vx.enterAltScreen(tty.writer());
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
     var env = try std.process.getEnvMap(alloc);
     defer env.deinit();
 
@@ -82,7 +82,7 @@ pub fn main() !void {
                     try vt.update(.{ .key_press = key });
                 },
                 .winsize => |ws| {
-                    try vx.resize(alloc, tty.anyWriter(), ws);
+                    try vx.resize(alloc, tty.writer(), ws);
                 },
             }
         }

--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -362,6 +362,10 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                     log.info("color_scheme_updates capability detected", .{});
                     vx.caps.color_scheme_updates = true;
                 },
+                .cap_multi_cursor => {
+                    log.info("multi cursor capability detected", .{});
+                    vx.caps.multi_cursor = true;
+                },
                 .cap_da1 => {
                     std.Thread.Futex.wake(&vx.query_futex, 10);
                     vx.queries_done.store(true, .unordered);

--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -58,7 +58,7 @@ pub fn Loop(comptime T: type) type {
             if (self.thread == null) return;
             self.should_quit = true;
             // trigger a read
-            self.vaxis.deviceStatusReport(self.tty.anyWriter()) catch {};
+            self.vaxis.deviceStatusReport(self.tty.writer()) catch {};
 
             if (self.thread) |thread| {
                 thread.join();
@@ -398,7 +398,7 @@ test Loop {
     defer tty.deinit();
 
     var vx = try vaxis.init(std.testing.allocator, .{});
-    defer vx.deinit(std.testing.allocator, tty.anyWriter());
+    defer vx.deinit(std.testing.allocator, tty.writer());
 
     var loop: vaxis.Loop(Event) = .{ .tty = &tty, .vaxis = &vx };
     try loop.init();
@@ -407,6 +407,6 @@ test Loop {
     defer loop.stop();
 
     // Optionally enter the alternate screen
-    try vx.enterAltScreen(tty.anyWriter());
-    try vx.queryTerminal(tty.anyWriter(), 1 * std.time.ns_per_ms);
+    try vx.enterAltScreen(tty.writer());
+    try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_ms);
 }

--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -1411,6 +1411,6 @@ pub fn setTerminalWorkingDirectory(_: *Vaxis, tty: *IoWriter, path: []const u8) 
         .host = .{ .raw = hostname },
         .path = .{ .raw = path },
     };
-    try tty.print(ctlseqs.osc7, .{uri});
+    try tty.print(ctlseqs.osc7, .{uri.fmt(.{ .scheme = true, .authority = true, .path = true })});
     try tty.flush();
 }

--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -38,6 +38,7 @@ pub const Capabilities = struct {
     color_scheme_updates: bool = false,
     explicit_width: bool = false,
     scaled_text: bool = false,
+    multi_cursor: bool = false,
 };
 
 pub const Options = struct {
@@ -300,6 +301,7 @@ pub fn queryTerminalSend(vx: *Vaxis, tty: *IoWriter) !void {
         // why we see a Shift modifier
         ctlseqs.home ++
         ctlseqs.scaled_text_query ++
+        ctlseqs.multi_cursor_query ++
         ctlseqs.cursor_position_request ++
         ctlseqs.xtversion ++
         ctlseqs.csi_u_query ++

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -123,7 +123,7 @@ pub const strikethrough_reset = "\x1b[29m";
 
 // OSC sequences
 pub const osc2_set_title = "\x1b]2;{s}\x1b\\";
-pub const osc7 = "\x1b]7;{;+/}\x1b\\";
+pub const osc7 = "\x1b]7;{f}\x1b\\";
 pub const osc8 = "\x1b]8;{s};{s}\x1b\\";
 pub const osc8_clear = "\x1b]8;;\x1b\\";
 pub const osc9_notify = "\x1b]9;{s}\x1b\\";

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -14,6 +14,7 @@ pub const sixel_geometry_query = "\x1b[?2;1;0S";
 pub const cursor_position_request = "\x1b[6n";
 pub const explicit_width_query = "\x1b]66;w=1; \x1b\\";
 pub const scaled_text_query = "\x1b]66;s=2; \x1b\\";
+pub const multi_cursor_query = "\x1b[> q";
 
 // mouse. We try for button motion and any motion. terminals will enable the
 // last one we tried (any motion). This was added because zellij doesn't

--- a/src/event.zig
+++ b/src/event.zig
@@ -26,4 +26,5 @@ pub const Event = union(enum) {
     cap_unicode,
     cap_da1,
     cap_color_scheme_updates,
+    cap_multi_cursor,
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -73,7 +73,7 @@ pub fn recover() void {
             ctlseqs.bp_reset ++
             ctlseqs.rmcup;
 
-        gty.anyWriter().writeAll(reset) catch {};
+        gty.writer().writeAll(reset) catch {};
 
         gty.deinit();
     }

--- a/src/tty.zig
+++ b/src/tty.zig
@@ -33,8 +33,6 @@ pub const PosixTty = struct {
     /// The file descriptor of the tty
     fd: posix.fd_t,
 
-    reader: std.fs.File.Reader,
-
     /// File.Writer for efficient buffered writing
     tty_writer: std.fs.File.Writer,
 
@@ -76,7 +74,6 @@ pub const PosixTty = struct {
         const self: PosixTty = .{
             .fd = fd,
             .termios = termios,
-            .reader = file.reader(buffer),
             .tty_writer = .initStreaming(file, buffer),
         };
 

--- a/src/widgets/terminal/ansi.zig
+++ b/src/widgets/terminal/ansi.zig
@@ -55,33 +55,26 @@ pub const CSI = struct {
         return .{ .bytes = self.params };
     }
 
-    pub fn format(
-        self: CSI,
-        comptime layout: []const u8,
-        opts: std.fmt.FormatOptions,
-        writer: anytype,
-    ) !void {
-        _ = layout;
-        _ = opts;
+    pub fn format(self: CSI, writer: anytype) !void {
         if (self.private_marker == null and self.intermediate == null)
-            try std.fmt.format(writer, "CSI {s} {c}", .{
+            try writer.print("CSI {s} {c}", .{
                 self.params,
                 self.final,
             })
         else if (self.private_marker != null and self.intermediate == null)
-            try std.fmt.format(writer, "CSI {c} {s} {c}", .{
+            try writer.print("CSI {c} {s} {c}", .{
                 self.private_marker.?,
                 self.params,
                 self.final,
             })
         else if (self.private_marker == null and self.intermediate != null)
-            try std.fmt.format(writer, "CSI {s} {c} {c}", .{
+            try writer.print("CSI {s} {c} {c}", .{
                 self.params,
                 self.intermediate.?,
                 self.final,
             })
         else
-            try std.fmt.format(writer, "CSI {c} {s} {c} {c}", .{
+            try writer.print("CSI {c} {s} {c} {c}", .{
                 self.private_marker.?,
                 self.params,
                 self.intermediate.?,

--- a/src/widgets/terminal/key.zig
+++ b/src/widgets/terminal/key.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const vaxis = @import("../../main.zig");
 
 pub fn encode(
-    writer: std.io.AnyWriter,
+    writer: *std.Io.Writer,
     key: vaxis.Key,
     press: bool,
     kitty_flags: vaxis.Key.KittyFlags,
@@ -19,7 +19,7 @@ pub fn encode(
     }
 }
 
-fn legacy(writer: std.io.AnyWriter, key: vaxis.Key) !void {
+fn legacy(writer: *std.Io.Writer, key: vaxis.Key) !void {
     // If we have text, we always write it directly
     if (key.text) |text| {
         try writer.writeAll(text);


### PR DESCRIPTION
This collection of commits gets the terminal example and the flow control editor working again with zig-0.15.

Additionally, there is a refactor to rename anyWriter() to just writer() and one to remove the unused reader in PosixTty.

As this is the fix list from Flow Control it is rebased onto the multi cursor support PR, so you might want to merge that first.