### PR TITLE
Fix `sendNotification` for zig-0.15

### DIFF
--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -161,7 +161,7 @@ pub const EventContext = struct {
         maybe_title: ?[]const u8,
         body: []const u8,
     ) Allocator.Error!void {
-        const alloc = self.cmds.allocator;
+        const alloc = self.alloc;
         if (maybe_title) |title| {
             return self.addCmd(.{ .notify = .{
                 .title = try alloc.dupe(u8, title),


### PR DESCRIPTION
Using `sendNotification` leads to the `error: no field named 'allocator' in struct 'array_list.Aligned(vxfw.vxfw.Command,null)'`.

I believe this is simply due to `std.array_list`'s allocator no longer being exposed in zig-0.15.

This 1 line fix simply uses the `EventContext`'s own allocator.