### PR TITLE
fix: make bracketed paste work like osc 52 paste

### DIFF
--- a/src/Loop.zig
+++ b/src/Loop.zig
@@ -302,16 +302,6 @@ pub fn handleEventGeneric(self: anytype, vx: *Vaxis, cache: *GraphemeCache, Even
                         return self.postEvent(.focus_out);
                     }
                 },
-                .paste_start => {
-                    if (@hasField(Event, "paste_start")) {
-                        return self.postEvent(.paste_start);
-                    }
-                },
-                .paste_end => {
-                    if (@hasField(Event, "paste_end")) {
-                        return self.postEvent(.paste_end);
-                    }
-                },
                 .paste => |text| {
                     if (@hasField(Event, "paste")) {
                         return self.postEvent(.{ .paste = text });

--- a/src/event.zig
+++ b/src/event.zig
@@ -11,9 +11,7 @@ pub const Event = union(enum) {
     mouse_leave,
     focus_in,
     focus_out,
-    paste_start, // bracketed paste start
-    paste_end, // bracketed paste end
-    paste: []const u8, // osc 52 paste, caller must free
+    paste: []const u8, // osc 52, bracketed paste, caller must free
     color_report: Color.Report, // osc 4, 10, 11, 12 response
     color_scheme: Color.Scheme,
     winsize: Winsize,

--- a/src/vxfw/vxfw.zig
+++ b/src/vxfw/vxfw.zig
@@ -40,9 +40,7 @@ pub const Event = union(enum) {
     mouse: vaxis.Mouse,
     focus_in, // window has gained focus
     focus_out, // window has lost focus
-    paste_start, // bracketed paste start
-    paste_end, // bracketed paste end
-    paste: []const u8, // osc 52 paste, caller must free
+    paste: []const u8, // osc 52, bracketed paste, caller must free
     color_report: vaxis.Color.Report, // osc 4, 10, 11, 12 response
     color_scheme: vaxis.Color.Scheme, // light / dark OS theme changes
     winsize: vaxis.Winsize, // the window size has changed. This event is always sent when the loop is started


### PR DESCRIPTION
Fixes #85

Some notes:
- As mentioned in the issue, the `paste_allocator` is unwrapped without any checks. After some testing, when it is `null` and cannot be unwrapped the zig compiler complains. So I took the liberty to add checks on the OSC 52 paste as well.
- The way the paste event works currently needs the caller to free the text. In vxfw widgets, the events can be `paste`, but none of them handle that possibility leading to memory leaks. I will open another issue about this.
- I'm not sure what was going on with the loop, it worked well and I imagine this is because escape sequences are almost always read in one go. But as soon as I started sending sequences in chunks, I got some weird and unexpected behaviour. This should be fixed with my changes, but it should definitely be checked in case I overlooked something.
- The current implementation of the loop uses a fixed size buffer, leading to problems when an escape sequence is bigger than the buffer (pretty sure it only happens when pasting). For now I'm returning an `error.EscapeSequenceTooLong` but it might be better to implement a dynamic buffer in the case it ever exceeds the fixed size.