### PR TITLE
Fix compile errors in `vxfw.App` and examples

### DIFF
--- a/examples/cli.zig
+++ b/examples/cli.zig
@@ -29,7 +29,7 @@ pub fn main() !void {
 
     try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
-    var text_input = TextInput.init(alloc, &vx.unicode);
+    var text_input = TextInput.init(alloc);
     defer text_input.deinit();
 
     var selected_option: ?usize = null;

--- a/examples/table.zig
+++ b/examples/table.zig
@@ -66,7 +66,7 @@ pub fn main() !void {
     };
     var title_segs = [_]vaxis.Cell.Segment{ title_logo, title_info, title_disclaimer };
 
-    var cmd_input = vaxis.widgets.TextInput.init(alloc, &vx.unicode);
+    var cmd_input = vaxis.widgets.TextInput.init(alloc);
     defer cmd_input.deinit();
 
     // Colors

--- a/examples/view.zig
+++ b/examples/view.zig
@@ -68,7 +68,7 @@ pub fn main() !void {
 
     // Initialize Views
     // - Large Map
-    var lg_map_view = try View.init(alloc, &vx.unicode, .{ .width = lg_map_width, .height = lg_map_height });
+    var lg_map_view = try View.init(alloc, .{ .width = lg_map_width, .height = lg_map_height });
     defer lg_map_view.deinit();
     //w = lg_map_view.screen.width;
     //h = lg_map_view.screen.height;
@@ -76,7 +76,7 @@ pub fn main() !void {
     _ = mem.replace(u8, lg_world_map, "\n", "", lg_map_buf[0..]);
     _ = lg_map_view.printSegment(.{ .text = lg_map_buf[0..] }, .{ .wrap = .grapheme });
     // - Small Map
-    var sm_map_view = try View.init(alloc, &vx.unicode, .{ .width = sm_map_width, .height = sm_map_height });
+    var sm_map_view = try View.init(alloc, .{ .width = sm_map_width, .height = sm_map_height });
     defer sm_map_view.deinit();
     w = sm_map_view.screen.width;
     h = sm_map_view.screen.height;

--- a/examples/vt.zig
+++ b/examples/vt.zig
@@ -54,7 +54,6 @@ pub fn main() !void {
         alloc,
         &argv,
         &env,
-        &vx.unicode,
         vt_opts,
         &write_buf,
     );

--- a/src/vxfw/App.zig
+++ b/src/vxfw/App.zig
@@ -80,8 +80,7 @@ pub fn run(self: *App, widget: vxfw.Widget, opts: Options) anyerror!void {
     vx.caps.sgr_pixels = false;
     try vx.setMouseMode(tty.writer(), true);
 
-    // Give DrawContext the unicode data
-    vxfw.DrawContext.init(&vx.unicode, vx.screen.width_method);
+    vxfw.DrawContext.init(vx.screen.width_method);
 
     const framerate: u64 = if (opts.framerate > 0) opts.framerate else 60;
     // Calculate tick rate


### PR DESCRIPTION
The `ucd` arg to most `init` functions doesn't exist anymore.
I've successfully compiled all examples and I have a project using `vxfw.App` which compiles again with this patch.