### PR TITLE
Use the new uucode grapheme iterator API

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -10,8 +10,8 @@
             .hash = "zigimg-0.1.0-8_eo2vHnEwCIVW34Q14Ec-xUlzIoVg86-7FU2ypPtxms",
         },
         .uucode = .{
-            .url = "git+https://github.com/jacobsandlund/uucode#fd35419ee2417d19af7a3db68d3dec986e2e7979",
-            .hash = "uucode-0.1.0-ZZjBPjtEQwAzu_Rx9VlJIP8j8rTSB8adTnOC1n9HXAQz",
+            .url = "git+https://github.com/jacobsandlund/uucode#6c78444cd405cd5345cf451ea20456ec93c199b0",
+            .hash = "uucode-0.1.0-ZZjBPtdNQwD9MXAFsVinea-vzHwBai_GiNr-VL8xDagI",
         },
     },
     .paths = .{

--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -114,11 +114,11 @@ inline fn parseGround(input: []const u8) !Result {
 
             // Check if we have a multi-codepoint grapheme
             var code = first_cp;
-            var grapheme_iter = uucode.grapheme.Iterator(uucode.utf8.Iterator).init(.init(input));
+            var grapheme_iter = uucode.grapheme.utf8Iterator(input);
             var grapheme_len: usize = 0;
             var cp_count: usize = 0;
 
-            while (grapheme_iter.next()) |result| {
+            while (grapheme_iter.nextCodepoint()) |result| {
                 cp_count += 1;
                 if (result.is_break) {
                     // Found the first grapheme boundary

--- a/src/widgets/TextView.zig
+++ b/src/widgets/TextView.zig
@@ -77,12 +77,12 @@ pub const Buffer = struct {
     /// Appends content to the buffer.
     pub fn append(self: *@This(), allocator: std.mem.Allocator, content: Content) Error!void {
         var cols: usize = self.last_cols;
-        var iter = uucode.grapheme.Iterator(uucode.utf8.Iterator).init(.init(content.bytes));
+        var iter = uucode.grapheme.utf8Iterator(content.bytes);
 
         var grapheme_start: usize = 0;
         var prev_break: bool = true;
 
-        while (iter.next()) |result| {
+        while (iter.nextCodepoint()) |result| {
             if (prev_break and !result.is_break) {
                 // Start of a new grapheme
                 grapheme_start = iter.i - std.unicode.utf8CodepointSequenceLength(result.cp) catch 1;


### PR DESCRIPTION
This uses the updated grapheme iteration API (with one fix for `unverifiedWcwidth`), from this PR: https://github.com/jacobsandlund/uucode/pull/16

This gets the number of failures down to 3, and they are:

* "gwidth: emoji with ZWJ" - fails on `gwidth("👩‍🚀", .wcwidth)` because the `uucode` `wcwidth` is seeing that the EMOJI MODIFIER FITZPATRICK is East Asian Width: wide, and doesn't handle these correctly.
* "gwidth: emoji with VS16 selector" because the `uucode` `wcwidth` isn't taking into account VS16 yet
* "gwidth: keycap sequence" because the `uucode` `wcwidth` isn't taking into account keycap sequences yet (again, VS16 related)