### PR TITLE
vxfw.ScrollView: fix cursored line not displaying

### DIFF
--- a/src/vxfw/ScrollView.zig
+++ b/src/vxfw/ScrollView.zig
@@ -464,7 +464,7 @@ fn drawBuilder(self: *ScrollView, ctx: vxfw.DrawContext, builder: Builder) Alloc
         const cursor_surf = try vxfw.Surface.initWithChildren(
             ctx.arena,
             self.widget(),
-            .{ .width = child_offset, .height = child.surface.size.height },
+            .{ .width = child_offset + child.surface.size.width, .height = child.surface.size.height },
             sub,
         );
         for (0..cursor_surf.size.height) |row| {


### PR DESCRIPTION
Setting `draw_cursor = true` in `vxfw.ScrollView` would previously cause the cursored line to only display the cursor and not the actual content of the line.

Simple repro:
```diff
diff --git a/examples/scroll.zig b/examples/scroll.zig
index 0f92573..7b5e816 100644
--- a/examples/scroll.zig
+++ b/examples/scroll.zig
@@ -174,6 +174,7 @@ pub fn main() !void {
                         .buildFn = Model.widgetBuilder,
                     },
                 },
+                .draw_cursor = true,
             },
             // NOTE: This is not the actual content height, but rather an estimate. In reality
             //       you would want to do some calculations to keep this up to date and as close to
```
```
$ zig build example -Dexample=scroll
```