### PR TITLE
Add missing flush in recover

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -72,7 +72,7 @@ pub fn recover() void {
             ctlseqs.rmcup;
 
         gty.writer().writeAll(reset) catch {};
-
+        gty.writer().flush() catch {};
         gty.deinit();
     }
 }


### PR DESCRIPTION
`vaxis.recover()` is missing a flush which will leave the terminal in a bad state after a panic.