### PR TITLE
fix double free in fuzzy example

### DIFF
--- a/examples/fuzzy.zig
+++ b/examples/fuzzy.zig
@@ -4,6 +4,7 @@ const vxfw = vaxis.vxfw;
 
 const Model = struct {
     list: std.ArrayList(vxfw.Text),
+    /// Memory owned by .arena
     filtered: std.ArrayList(vxfw.RichText),
     list_view: vxfw.ListView,
     text_field: vxfw.TextField,
@@ -197,7 +198,6 @@ pub fn main() !void {
     };
     defer model.text_field.deinit();
     defer model.list.deinit(allocator);
-    defer model.filtered.deinit(allocator);
     defer model.arena.deinit();
 
     // Run the command


### PR DESCRIPTION
closes #270 

items of `model.filtered` are allocated via `model.arena`, hence freeing it with the root allocator and then deiniting `model.arena` causes a number of problems including but not limited to double-free, segfault and invalid free.

e.g.:

```
error(gpa): Allocation size 1024 bytes does not match free size 520. Allocation:
...
/home/bevicted/dev/accesspoint/src/tui.zig:198:30: 0x1165216 in run (main.zig)
        model.filtered.deinit(allocator);
                             ^
```

```
thread 240390 panic: Invalid free
...
/home/bevicted/dev/accesspoint/src/tui.zig:198:30: 0x1165216 in run (main.zig)
        model.filtered.deinit(allocator);
                             ^
```

## Testing:

### Problem exists at prev commit:

<img width="642" height="163" alt="image" src="https://github.com/user-attachments/assets/7aa98ef9-1eed-46c9-8b38-2b9b9440aac1" />

### Fix removes the problem

<img width="582" height="162" alt="image" src="https://github.com/user-attachments/assets/5059d6e4-3b08-4f0f-aa17-ddc44303206e" />

I've also ran this in my project that checks for memory leaks and there's none detected.

PS: Thanks for the cool library