### PR TITLE
add forward_delete key on macos

### DIFF
--- a/src/Key.zig
+++ b/src/Key.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const testing = std.testing;
+const builtin = @import("builtin");
 
 const Key = @This();
 
@@ -163,6 +164,11 @@ pub const enter: u21 = 0x0D;
 pub const escape: u21 = 0x1B;
 pub const space: u21 = 0x20;
 pub const backspace: u21 = 0x7F;
+
+// For whatever reason, when you press cmd+backspace on macOS it's encoded as ctrl+forward_delete.
+// forward_delete is encoded as 0x75, as per kVK_ForwardDelete in
+// /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h
+pub const forward_delete: u21 = if (builtin.os.tag == .macos) 0x75 else @compileError("forward_delete is only ever checked on macOS");
 
 /// multicodepoint is a key which generated text but cannot be expressed as a
 /// single codepoint. The value is the maximum unicode codepoint + 1


### PR DESCRIPTION
Noticed this while working on [Fönn](https://github.com/reykjalin/fn). For whatever reason pressing <kbd>Cmd + backspace</kbd> on macOS is encoded like so:

```zig
.{
    .codepoint = 117, // == 0x75
    .text = null,
    .shifted_codepoint = null,
    .base_layout_codepoint = null,
    .mods = .{
        // note that `ctrl` is `true`, not `super`. Another oddity here.
        .shift = false, .alt = false, .ctrl = true,
        .super = false, .hyper = false, .meta = false,
        .caps_lock = false, .num_lock = false
    }
}
```

I don't know _why_ macOS does this, but a quick lookup led me to `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Carbon.framework/Versions/A/Frameworks/HIToolbox.framework/Versions/A/Headers/Events.h` (on modern macOS systems as I understand it, the path has changed over the years) which has this section of code:

```C
/* keycodes for keys that are independent of keyboard layout*/
enum {
  // bunch of kVK_ prefixed keys...

  kVK_ForwardDelete             = 0x75,

  // ...
};

```

Having this keycode makes it easier to read the input handling code, so I figured I'd contribute, but let me know if this is something you'd like to keep or not rockorager.

***

I'm not quite convinced that the compile time error for trying to use this on non-macos systems is needed, but I figured it'd be better to err on the side of caution here instead of adding a new constant that may or may not be universal.

I think it's macOS specific since it's part of Apple's Carbon framework.