### PR TITLE
Add 0xDF virtual key code mapping for backslash on Turkish keyboard

### DIFF
--- a/src/tty.zig
+++ b/src/tty.zig
@@ -453,6 +453,7 @@ pub const WindowsTty = struct {
                     0xc0 => '`',
                     0xdb => '[',
                     0xdc => '\\',
+                    0xdf => '\\',
                     0xe2 => '\\',
                     0xdd => ']',
                     0xde => '\'',


### PR DESCRIPTION
On Turkish keyboard layouts, the backslash key sends virtual key code `0xDF`.

For example: C:\Users\BeratHundurel\Backgrounds\64624b4a-6293-4b80-91d5-9ce1f7ad35a6.jpg

This causes backslash characters to be dropped entirely when typing or pasting file paths on Windows.

This fix adds the missing mapping.

Before: 
<img width="1573" height="300" alt="broken" src="https://github.com/user-attachments/assets/50430f7f-a121-4987-b8ee-934d6fe13222" />

After:
<img width="1171" height="283" alt="fixed" src="https://github.com/user-attachments/assets/813fdb5c-5da3-4dee-a261-162369d5e5e0" />

