### PR TITLE
fix: resolve performance issue and memory leak in table example

### DIFF
--- a/examples/table.zig
+++ b/examples/table.zig
@@ -35,7 +35,6 @@ pub fn main() !void {
     var loop: vaxis.Loop(union(enum) {
         key_press: vaxis.Key,
         winsize: vaxis.Winsize,
-        table_upd,
     }) = .{ .tty = &tty, .vaxis = &vx };
     try loop.init();
     try loop.start();
@@ -188,7 +187,6 @@ pub fn main() !void {
                 moving = false;
             },
             .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
-            else => {},
         }
 
         // Content
@@ -238,7 +236,6 @@ pub fn main() !void {
                     return see_win.height;
                 }
             }.see;
-            loop.postEvent(.table_upd);
         }
 
         // Sections

--- a/examples/table.zig
+++ b/examples/table.zig
@@ -21,6 +21,7 @@ pub fn main() !void {
 
     // Users set up below the main function
     const users_buf = try alloc.dupe(User, users[0..]);
+    defer alloc.free(users_buf);
 
     var buffer: [1024]u8 = undefined;
     var tty = try vaxis.Tty.init(&buffer);


### PR DESCRIPTION
The table_upd event was causing the table example to enter into a redrawing loop whenever the row content was showing. The postEvent would trigger another postEvent and a redraw.

I removed the table_upd event completely as unnecessary, as changing the active_content_fn is enough by itself for the row content to show without needing a table update event.

I also added the missing free for users_buf, mostly to disable the memory leak warnings when exiting the program.