### PR TITLE
fix: ensure examples building

### DIFF
--- a/examples/cli.zig
+++ b/examples/cli.zig
@@ -4,6 +4,14 @@ const Cell = vaxis.Cell;
 const TextInput = vaxis.widgets.TextInput;
 
 const log = std.log.scoped(.main);
+
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .main, .level = .err },
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer {
@@ -27,6 +35,7 @@ pub fn main() !void {
     try loop.start();
     defer loop.stop();
 
+    try vx.enterAltScreen(tty.writer());
     try vx.queryTerminal(tty.writer(), 1 * std.time.ns_per_s);
 
     var text_input = TextInput.init(alloc);
@@ -65,7 +74,7 @@ pub fn main() !void {
                     }
                 } else if (key.matches(vaxis.Key.enter, .{}) or key.matches('j', .{ .ctrl = true })) {
                     if (selected_option) |i| {
-                        log.err("enter", .{});
+                        log.debug("enter", .{});
                         try text_input.insertSliceAtCursor(options[i]);
                         selected_option = null;
                     }
@@ -88,7 +97,7 @@ pub fn main() !void {
         if (selected_option) |i| {
             win.hideCursor();
             for (options, 0..) |opt, j| {
-                log.err("i = {d}, j = {d}, opt = {s}", .{ i, j, opt });
+                log.debug("i = {d}, j = {d}, opt = {s}", .{ i, j, opt });
                 var seg = [_]vaxis.Segment{.{
                     .text = opt,
                     .style = if (j == i) .{ .reverse = true } else .{},

--- a/examples/counter.zig
+++ b/examples/counter.zig
@@ -2,6 +2,12 @@ const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 /// Our main application state
 const Model = struct {
     /// State of the counter

--- a/examples/image.zig
+++ b/examples/image.zig
@@ -3,6 +3,13 @@ const vaxis = @import("vaxis");
 
 const log = std.log.scoped(.main);
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .main , .level = .err },
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 const Event = union(enum) {
     key_press: vaxis.Key,
     winsize: vaxis.Winsize,
@@ -40,9 +47,8 @@ pub fn main() !void {
 
     const imgs = [_]vaxis.Image{
         try vx.transmitImage(alloc, tty.writer(), &img1, .rgba),
-        // var img1 = try vaxis.zigimg.Image.fromFilePath(alloc, "examples/zig.png");
-        // try vx.loadImage(alloc, tty.writer(), .{ .path = "examples/zig.png" }),
-        try vx.loadImage(alloc, tty.writer(), .{ .path = "examples/vaxis.png" }),
+        try vx.loadImage(alloc, tty.writer(), .{ .path = "examples/zig.png" }),
+        // try vx.loadImage(alloc, tty.writer(), .{ .path = "examples/vaxis.png" }),
     };
     defer vx.freeImage(tty.writer(), imgs[0].id);
     defer vx.freeImage(tty.writer(), imgs[1].id);

--- a/examples/list_view.zig
+++ b/examples/list_view.zig
@@ -6,6 +6,12 @@ const Text = vxfw.Text;
 const ListView = vxfw.ListView;
 const Widget = vxfw.Widget;
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 const Model = struct {
     list_view: ListView,
 

--- a/examples/main.zig
+++ b/examples/main.zig
@@ -3,6 +3,14 @@ const vaxis = @import("vaxis");
 const Cell = vaxis.Cell;
 
 const log = std.log.scoped(.main);
+
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .main, .level = .err },
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer {

--- a/examples/scroll.zig
+++ b/examples/scroll.zig
@@ -2,6 +2,12 @@ const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 const ModelRow = struct {
     text: []const u8,
     idx: usize,

--- a/examples/split_view.zig
+++ b/examples/split_view.zig
@@ -2,6 +2,14 @@ const std = @import("std");
 const vaxis = @import("vaxis");
 const vxfw = vaxis.vxfw;
 
+
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
+
 const Model = struct {
     split: vxfw.SplitView,
     lhs: vxfw.Text,

--- a/examples/table.zig
+++ b/examples/table.zig
@@ -8,6 +8,13 @@ const vaxis = @import("vaxis");
 
 const log = std.log.scoped(.main);
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .main, .level = .err },
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 const ActiveSection = enum {
     top,
     mid,
@@ -21,6 +28,7 @@ pub fn main() !void {
 
     // Users set up below the main function
     const users_buf = try alloc.dupe(User, users[0..]);
+    defer alloc.free(users_buf);
 
     var buffer: [1024]u8 = undefined;
     var tty = try vaxis.Tty.init(&buffer);

--- a/examples/text_input.zig
+++ b/examples/text_input.zig
@@ -6,6 +6,13 @@ const border = vaxis.widgets.border;
 
 const log = std.log.scoped(.main);
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .main, .level = .err },
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 // Our Event. This can contain internal events as well as Vaxis events.
 // Internal events can be posted into the same queue as vaxis events to allow
 // for a single event loop with exhaustive switching. Booya

--- a/examples/text_view.zig
+++ b/examples/text_view.zig
@@ -9,6 +9,12 @@ const Event = union(enum) {
     winsize: vaxis.Winsize,
 };
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
 
@@ -47,7 +53,7 @@ pub fn main() !void {
         switch (event) {
             .key_press => |key| {
                 // Close demo
-                if (key.matches('c', .{})) break;
+                if (key.matches('c', .{}) or key.matches('c', .{ .ctrl = true })) break;
                 if (key.matches(vaxis.Key.enter, .{})) {
                     counter += 1;
                     const new_content = try std.fmt.bufPrint(&lineBuf, "\nLine {d}", .{counter});
@@ -57,10 +63,11 @@ pub fn main() !void {
             },
             .winsize => |ws| try vx.resize(alloc, tty.writer(), ws),
         }
+
         const win = vx.window();
         win.clear();
         text_view.draw(win, text_view_buffer);
         try vx.render(tty.writer());
-        try tty.writer.flush();
+        try tty.writer().flush();
     }
 }

--- a/examples/vaxis.zig
+++ b/examples/vaxis.zig
@@ -9,6 +9,12 @@ const Event = union(enum) {
 
 pub const panic = vaxis.panic_handler;
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer {

--- a/examples/view.zig
+++ b/examples/view.zig
@@ -13,6 +13,13 @@ const Event = union(enum) {
     winsize: vaxis.Winsize,
 };
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .main, .level = .err },
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer {

--- a/src/Image.zig
+++ b/src/Image.zig
@@ -4,6 +4,12 @@ const math = std.math;
 const base64 = std.base64.standard.Encoder;
 const zigimg = @import("zigimg");
 
+pub const std_options: std.Options = .{
+    .log_scope_levels = &[_]std.log.ScopeLevel{
+        .{ .scope = .vaxis, .level = .err },
+    },
+};
+
 const Window = @import("Window.zig");
 
 const Image = @This();

--- a/src/vxfw/App.zig
+++ b/src/vxfw/App.zig
@@ -463,8 +463,8 @@ const MouseHandler = struct {
         ctx.phase = .capturing;
         for (hits.items) |item| {
             var m_local = mouse;
-            m_local.col = item.local.col;
-            m_local.row = item.local.row;
+            m_local.col = @intCast(item.local.col);
+            m_local.row = @intCast(item.local.row);
             try item.widget.captureEvent(ctx, .{ .mouse = m_local });
             try app.handleCommand(&ctx.cmds);
 
@@ -475,8 +475,8 @@ const MouseHandler = struct {
         ctx.phase = .at_target;
         {
             var m_local = mouse;
-            m_local.col = target.local.col;
-            m_local.row = target.local.row;
+            m_local.col = @intCast(target.local.col);
+            m_local.row = @intCast(target.local.row);
             try target.widget.handleEvent(ctx, .{ .mouse = m_local });
             try app.handleCommand(&ctx.cmds);
 
@@ -487,8 +487,8 @@ const MouseHandler = struct {
         ctx.phase = .bubbling;
         while (hits.pop()) |item| {
             var m_local = mouse;
-            m_local.col = item.local.col;
-            m_local.row = item.local.row;
+            m_local.col = @intCast(item.local.col);
+            m_local.row = @intCast(item.local.row);
             try item.widget.handleEvent(ctx, .{ .mouse = m_local });
             try app.handleCommand(&ctx.cmds);
 


### PR DESCRIPTION
Nice library, to see if I wanted to use it I proposed a few fixes.

A few changes:

- Made a few examples were not building, due to changes in zig 0.15.1 and bugs in the library.
- Fixed two cleanup bugs.
- For the image example, the image "vaxis.png" was giving me EOF errors. However, "zig.png" works so I switched to that.
- Suppressed logging on the examples as it was printing during the examples. In some cases, it also prevents a small flicker on startup, where it briefly prints before the app starts. Let me know if you think this approach is suitable.

If theres anything about the way I've done it that isn't agreeable let me know, I'm happy to make the changes for you.