### PR TITLE
fix(CodeView): explicit casts for `pad_left`

### DIFF
--- a/src/widgets/CodeView.zig
+++ b/src/widgets/CodeView.zig
@@ -39,11 +39,11 @@ pub fn draw(self: *@This(), win: vaxis.Window, buffer: Buffer, opts: DrawOptions
         nl.draw(win.child(.{
             .x_off = 0,
             .y_off = 0,
-            .width = pad_left,
+            .width = @intCast(pad_left),
             .height = win.height,
         }), self.scroll_view.scroll.y);
     }
-    self.drawCode(win.child(.{ .x_off = pad_left }), buffer, opts);
+    self.drawCode(win.child(.{ .x_off = @intCast(pad_left) }), buffer, opts);
 }
 
 fn drawCode(self: *@This(), win: vaxis.Window, buffer: Buffer, opts: DrawOptions) void {


### PR DESCRIPTION
marked some casts as explicit with `@intCast()` to comply with compiler errors

compiling a hello world program to test `CodeView` spat out two errors about int casting in `widgets/CodeView.zig`, marking the casts as explicit with `@intCast()` made it compile properly and behave as expected