### PR TITLE
Add multi cursor add, set and color functions

### DIFF
--- a/src/InternalScreen.zig
+++ b/src/InternalScreen.zig
@@ -42,8 +42,6 @@ height: u16 = 0,
 
 buf: []InternalCell,
 
-cursor_row: u16 = 0,
-cursor_col: u16 = 0,
 cursor_vis: bool = false,
 cursor_shape: CursorShape = .default,
 

--- a/src/Screen.zig
+++ b/src/Screen.zig
@@ -8,6 +8,7 @@ const Winsize = @import("main.zig").Winsize;
 const Method = @import("gwidth.zig").Method;
 
 const Screen = @This();
+pub const Cursor = struct { row: u16 = 0, col: u16 = 0 };
 
 width: u16 = 0,
 height: u16 = 0,
@@ -17,9 +18,9 @@ height_pix: u16 = 0,
 
 buf: []Cell = &.{},
 
-cursor_row: u16 = 0,
-cursor_col: u16 = 0,
+cursor: Cursor = .{},
 cursor_vis: bool = false,
+cursor_secondary: []Cursor = &.{},
 
 width_method: Method = .wcwidth,
 

--- a/src/Vaxis.zig
+++ b/src/Vaxis.zig
@@ -799,7 +799,7 @@ pub fn render(self: *Vaxis, tty: *IoWriter) !void {
         self.state.cursor.row = cursor_pos.row;
         self.state.cursor.col = cursor_pos.col;
     }
-    if (self.screen.cursor_vis) {
+    if (self.screen.cursor_vis and self.caps.multi_cursor) {
         try tty.print(ctlseqs.reset_secondary_cursors, .{});
         for (self.screen.cursor_secondary) |cur|
             try tty.print(ctlseqs.show_secondary_cursor, .{ cur.row + 1, cur.col + 1 });
@@ -1136,9 +1136,11 @@ pub fn setTerminalCursorColor(self: *Vaxis, tty: *IoWriter, rgb: [3]u8) !void {
 
 /// Set the terminal secondary cursor color
 pub fn setTerminalCursorSecondaryColor(self: *Vaxis, tty: *IoWriter, rgb: [3]u8) error{WriteFailed}!void {
-    try tty.print(ctlseqs.secondary_cursors_rgb, .{ rgb[0], rgb[1], rgb[2] });
-    try tty.flush();
-    self.state.changed_cursor_color = true;
+    if (self.caps.multi_cursor) {
+        try tty.print(ctlseqs.secondary_cursors_rgb, .{ rgb[0], rgb[1], rgb[2] });
+        try tty.flush();
+        self.state.changed_cursor_color = true;
+    }
 }
 
 pub fn resetAllTerminalSecondaryCursors(self: *Vaxis, alloc: std.mem.Allocator) error{OutOfMemory}!void {

--- a/src/Window.zig
+++ b/src/Window.zig
@@ -248,8 +248,8 @@ pub fn showCursor(self: Window, col: u16, row: u16) void {
         col >= self.width)
         return;
     self.screen.cursor_vis = true;
-    self.screen.cursor_row = @intCast(row + self.y_off);
-    self.screen.cursor_col = @intCast(col + self.x_off);
+    self.screen.cursor.row = @intCast(row + self.y_off);
+    self.screen.cursor.col = @intCast(col + self.x_off);
 }
 
 pub fn setCursorShape(self: Window, shape: Cell.CursorShape) void {

--- a/src/ctlseqs.zig
+++ b/src/ctlseqs.zig
@@ -65,6 +65,11 @@ pub const ind = "\n";
 pub const cuf = "\x1b[{d}C";
 pub const cub = "\x1b[{d}D";
 
+// Multi Cursor
+pub const secondary_cursors_rgb = "\x1b[>40;2:{d}:{d}:{d} q";
+pub const reset_secondary_cursors = "\x1b[>0;4 q";
+pub const show_secondary_cursor = "\x1b[>29;2:{d}:{d} q";
+
 // Erase
 pub const erase_below_cursor = "\x1b[J";
 


### PR DESCRIPTION
This adds these functions:

- `setTerminalCursorSecondaryColor`
- `resetAllTerminalSecondaryCursors`
- `addTerminalSecondaryCursor`

and related rendering code.

Also, a minor refactoring to add a `Cursor` type for a little more consistent cursor handle.