### PR TITLE
vxfw FlexRow FlexColum and Border should respect context min sizes

### DIFF
--- a/src/vxfw/Border.zig
+++ b/src/vxfw/Border.zig
@@ -39,13 +39,15 @@ fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) Allocator.Error!vxfw
 /// before drawing the child. If the size is unbounded, border will draw the child and then itself
 /// around the childs size
 pub fn draw(self: *const Border, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Surface {
+    const min_width: u16 = ctx.min.width -| 2;
+    const min_height: u16 = ctx.min.height -| 2;
     const max_width: ?u16 = if (ctx.max.width) |width| width -| 2 else null;
     const max_height: ?u16 = if (ctx.max.height) |height| height -| 2 else null;
 
-    const child_ctx = ctx.withConstraints(ctx.min, .{
-        .width = max_width,
-        .height = max_height,
-    });
+    const child_ctx = ctx.withConstraints(
+        .{ .width = min_width, .height = min_height },
+        .{ .width = max_width, .height = max_height },
+    );
     const child = try self.child.draw(child_ctx);
 
     const children = try ctx.arena.alloc(vxfw.SubSurface, 1);

--- a/src/vxfw/FlexColumn.zig
+++ b/src/vxfw/FlexColumn.zig
@@ -70,7 +70,7 @@ pub fn draw(self: *const FlexColumn, ctx: vxfw.DrawContext) Allocator.Error!vxfw
 
         // Create a context for the child
         const child_ctx = ctx.withConstraints(
-            .{ .width = 0, .height = child_height },
+            .{ .width = ctx.min.width, .height = child_height },
             .{ .width = ctx.max.width.?, .height = child_height },
         );
         const surf = try child.widget.draw(child_ctx);

--- a/src/vxfw/FlexRow.zig
+++ b/src/vxfw/FlexRow.zig
@@ -70,7 +70,7 @@ pub fn draw(self: *const FlexRow, ctx: vxfw.DrawContext) Allocator.Error!vxfw.Su
 
         // Create a context for the child
         const child_ctx = ctx.withConstraints(
-            .{ .width = child_width, .height = 0 },
+            .{ .width = child_width, .height = ctx.min.height },
             .{ .width = child_width, .height = ctx.max.height.? },
         );
         const surf = try child.widget.draw(child_ctx);


### PR DESCRIPTION
# Problems
- If `FlexRow` is provided a minimum height on draw, its children will not fill that minimum height. Similarly for `FlexColumn` regarding the minimum width.

- `Border` does not account for its own width/height when given a non-zero min.

# Reproduction
Replace `examples/text_input.zig` with the following example and run `zig build example`.
<details><summary>Full example file</summary>
<p>

```zig
const std = @import("std");
const vaxis = @import("vaxis");
const vxfw = vaxis.vxfw;

const Model = struct {
    pub fn widget(self: *Model) vxfw.Widget {
        return .{
            .userdata = self,
            .eventHandler = Model.typeErasedEventHandler,
            .drawFn = Model.typeErasedDrawFn,
        };
    }

    fn typeErasedEventHandler(_: *anyopaque, ctx: *vxfw.EventContext, event: vxfw.Event) anyerror!void {
        switch (event) {
            .key_press => |key| {
                if (key.matches('c', .{ .ctrl = true })) {
                    ctx.quit = true;
                    return;
                }
            },
            else => {},
        }
    }

    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
        const self: *Model = @ptrCast(@alignCast(ptr));
        const max_size = ctx.max.size();

        const text_1: vxfw.Text = .{ .text = "Some text." };
        const border_1: vxfw.Border = .{
            .child = text_1.widget(),
            .labels = &.{.{ .text = "Box 1", .alignment = .top_left }},
        };

        const text_2: vxfw.Text = .{ .text = "Some more text." };
        const border_2: vxfw.Border = .{
            .child = text_2.widget(),
            .labels = &.{.{ .text = "Box 2", .alignment = .top_left }},
        };

        const flex_row: vxfw.FlexRow = .{
            .children = &.{
                .init(border_2.widget(), 1),
                .init(border_1.widget(), 1),
            },
        };

        const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
        children[0] = .{
            .origin = .{ .row = 0, .col = 0 },
            .surface = try flex_row.draw(ctx.withConstraints(
                .{ .width = 0, .height = max_size.height },
                ctx.max,
            )),
        };

        return .{
            .size = max_size,
            .widget = self.widget(),
            .buffer = &.{},
            .children = children,
        };
    }
};

pub fn main() !void {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    defer _ = gpa.deinit();

    const allocator = gpa.allocator();

    var app = try vxfw.App.init(allocator);
    defer app.deinit();

    const model = try allocator.create(Model);
    defer allocator.destroy(model);

    try app.run(model.widget(), .{});
}
```

</p>
</details> 

Relevant snippet draws a `FlexRow` containing 2 `Border`s, each containing a `Text`.

```zig
    fn typeErasedDrawFn(ptr: *anyopaque, ctx: vxfw.DrawContext) std.mem.Allocator.Error!vxfw.Surface {
        const self: *Model = @ptrCast(@alignCast(ptr));
        const max_size = ctx.max.size();

        const text_1: vxfw.Text = .{ .text = "Some text." };
        const border_1: vxfw.Border = .{
            .child = text_1.widget(),
            .labels = &.{.{ .text = "Box 1", .alignment = .top_left }},
        };

        const text_2: vxfw.Text = .{ .text = "Some more text." };
        const border_2: vxfw.Border = .{
            .child = text_2.widget(),
            .labels = &.{.{ .text = "Box 2", .alignment = .top_left }},
        };

        const flex_row: vxfw.FlexRow = .{
            .children = &.{
                .init(border_2.widget(), 1),
                .init(border_1.widget(), 1),
            },
        };

        const children = try ctx.arena.alloc(vxfw.SubSurface, 1);
        children[0] = .{
            .origin = .{ .row = 0, .col = 0 },
            .surface = try flex_row.draw(ctx.withConstraints(
                .{ .width = 0, .height = max_size.height },
                ctx.max,
            )),
        };

        return .{
            .size = max_size,
            .widget = self.widget(),
            .buffer = &.{},
            .children = children,
        };
    }
```

## Actual
The borders do not reach the bottom of the canvas.
<img width="932" height="637" alt="Screenshot 2026-02-21 at 21 47 19" src="https://github.com/user-attachments/assets/c145501f-0513-4fd0-9e13-ab8cb4c7bec8" />

## Expected
The borders reach the bottom of the canvas.
<img width="932" height="637" alt="Screenshot 2026-02-21 at 21 45 41" src="https://github.com/user-attachments/assets/58765129-b186-46c5-958a-003a001590fe" />

## Without the Border fix
The borders overflow the bottom of the canvas.
<img width="932" height="637" alt="Screenshot 2026-02-21 at 21 48 43" src="https://github.com/user-attachments/assets/a332d59c-3fa1-4777-ad96-1a7b8d2a1bb9" />