### PR TITLE
fix(vxfw): render Button background consistently in VSCode terminal

### DIFF
--- a/src/vxfw/Button.zig
+++ b/src/vxfw/Button.zig
@@ -17,10 +17,12 @@ userdata: ?*anyopaque = null,
 
 // Styles
 style: struct {
-    default: vaxis.Style = .{ .reverse = true },
-    mouse_down: vaxis.Style = .{ .fg = .{ .index = 4 }, .reverse = true },
-    hover: vaxis.Style = .{ .fg = .{ .index = 3 }, .reverse = true },
-    focus: vaxis.Style = .{ .fg = .{ .index = 5 }, .reverse = true },
+    // Use explicit fg/bg so terminals that don't render reverse-video on blank cells
+    // still show the full button area.
+    default: vaxis.Style = .{ .fg = .{ .index = 0 }, .bg = .{ .index = 7 } },
+    mouse_down: vaxis.Style = .{ .fg = .{ .index = 15 }, .bg = .{ .index = 4 } },
+    hover: vaxis.Style = .{ .fg = .{ .index = 0 }, .bg = .{ .index = 3 } },
+    focus: vaxis.Style = .{ .fg = .{ .index = 15 }, .bg = .{ .index = 5 } },
 } = .{},
 
 // State


### PR DESCRIPTION
## Summary

`vxfw.Button` used `reverse=true` styles for its background states.  
In VSCode's integrated terminal (xterm.js), reverse styling on space-filled cells does not reliably render as a visible 3-line button, while hit-testing still correctly treats it as 3 lines.

This changes Button state styles to explicit `fg/bg` colors so the full button area renders consistently across terminals.

## Minimal Reproduction

1. Run the counter/button example (or any app using `vxfw.Button` with height 3) in:
   - Windows Terminal
   - VSCode integrated terminal
2. Observe the `Click me!` button:
   - Windows Terminal: appears as 3 lines
   - VSCode integrated terminal: appears visually as 1 line
3. Move the mouse above/below the text row in VSCode:
   - hover/click detection still behaves as if the button is 3 lines tall

## Expected

The button should render as a visible 3-line block in both terminals.

## Fix

In `src/vxfw/Button.zig`, replace reverse-video-only styles with explicit `fg/bg` style pairs for:
- `default`
- `hover`
- `mouse_down`
- `focus`

This keeps layout/hit-testing unchanged and makes rendering terminal-agnostic.
