### PR TITLE
fix(parser): parse CSI Z as shift+tab

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -403,6 +403,17 @@ inline fn parseCsi(input: []const u8, text_buf: []u8) Result {
                 .n = sequence.len,
             };
         },
+        'Z' => {
+            // Legacy keys
+            // CSI Z
+            return .{
+                .event = .{ .key_press = .{
+                    .codepoint = Key.tab,
+                    .mods = .{ .shift = true },
+                } },
+                .n = sequence.len,
+            };
+        },
         '~' => {
             // Legacy keys
             // CSI number ~
@@ -852,6 +863,18 @@ test "parse: xterm shift+up" {
     const expected_event: Event = .{ .key_press = expected_key };
 
     try testing.expectEqual(6, result.n);
+    try testing.expectEqual(expected_event, result.event);
+}
+
+test "parse: xterm shift+tab" {
+    const alloc = testing.allocator_instance.allocator();
+    const input = "\x1b[Z";
+    var parser: Parser = .{};
+    const result = try parser.parse(input, alloc);
+    const expected_key: Key = .{ .codepoint = Key.tab, .mods = .{ .shift = true } };
+    const expected_event: Event = .{ .key_press = expected_key };
+
+    try testing.expectEqual(3, result.n);
     try testing.expectEqual(expected_event, result.event);
 }
 


### PR DESCRIPTION
## Summary
- add CSI `Z` handling in `Parser.parseCsi` to emit Shift+Tab (`Key.tab` with `mods.shift = true`)
- add parser test coverage for `\x1b[Z` (`parse: xterm shift+tab`)
- closes the gap reported for macOS terminals emitting CSI Z for Shift+Tab

## Testing
- zig build test