### PR TITLE
fix(examples): use tty.writer() flush call in text_view

### DIFF
--- a/examples/text_view.zig
+++ b/examples/text_view.zig
@@ -61,6 +61,6 @@ pub fn main() !void {
         win.clear();
         text_view.draw(win, text_view_buffer);
         try vx.render(tty.writer());
-        try tty.writer.flush();
+        try tty.writer().flush();
     }
 }


### PR DESCRIPTION
## Summary
- update `examples/text_view.zig` to call `tty.writer().flush()` instead of `tty.writer.flush()`
- fixes the Zig 0.15.2 compile-time API mismatch in the `text_view` example

## Testing
- manually reproduced failure before fix (`no field named 'writer' in struct 'tty.PosixTty'`)
- `zig build example -Dexample=text_view` now reaches runtime and fails opening `/dev/tty` in this non-interactive environment (expected here)