### PR TITLE
fix(examples): remove duplicate filtered field in fuzzy model

### DIFF
--- a/examples/fuzzy.zig
+++ b/examples/fuzzy.zig
@@ -11,7 +11,6 @@ const Model = struct {
 
     /// Used for filtered RichText Spans and result
     arena: std.heap.ArenaAllocator,
-    filtered: std.ArrayList(vxfw.RichText),
     result: []const u8,
 
     pub fn init(gpa: std.mem.Allocator) !*Model {


### PR DESCRIPTION
## Summary
- remove the duplicate `filtered` field declaration in `examples/fuzzy.zig` `Model`
- fixes the compile error caused by duplicate struct member names on Zig 0.15.x
- related to #295

## Testing
- `zig build example -Dexample=fuzzy` now launches successfully in an interactive terminal
- exiting with `c` returns exit code `130` (cancel path in the example)