### PR TITLE
fix: use readline-compatible word boundaries in text input widgets

### DIFF
--- a/src/vxfw/TextField.zig
+++ b/src/vxfw/TextField.zig
@@ -738,6 +738,18 @@ test "word motion with non-ASCII text" {
     try std.testing.expectEqualStrings("-latte", input.buf.secondHalf());
 }
 
+test "non-ASCII punctuation treated as word chars" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    // Em dash (U+2014, 3 bytes: E2 80 94) has bytes >= 0x80, so all bytes are
+    // classified as word chars. The entire string is one continuous "word" — the
+    // em dash does NOT act as a separator. This is a known limitation of the
+    // byte-based classifier.
+    try input.insertSliceAtCursor("hello\xe2\x80\x94world");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
 test "deleteWordBefore with non-ASCII text" {
     var input = TextField.init(std.testing.allocator);
     defer input.deinit();

--- a/src/vxfw/TextField.zig
+++ b/src/vxfw/TextField.zig
@@ -346,10 +346,11 @@ pub fn deleteAfterCursor(self: *TextField) void {
     self.buf.growGapRight(grapheme.len);
 }
 
-/// Returns true if the byte is a word constituent (alnum or underscore),
-/// matching readline/emacs word character classes.
+/// Returns true if the byte is a word constituent: ASCII alnum, underscore,
+/// or any non-ASCII byte (part of a multi-byte UTF-8 sequence). This ensures
+/// word motion never splits inside non-ASCII characters like accented letters.
 fn isWordChar(c: u8) bool {
-    return std.ascii.isAlphanumeric(c) or c == '_';
+    return std.ascii.isAlphanumeric(c) or c == '_' or c >= 0x80;
 }
 
 /// Moves the cursor backward by one word using character-class boundaries.
@@ -719,6 +720,31 @@ test "word motion with underscores treats them as word chars" {
     input.moveBackwardWordwise();
     try std.testing.expectEqualStrings("hello_world-", input.buf.firstHalf());
     input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "word motion with non-ASCII text" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("café-latte");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("café-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("latte", input.buf.secondHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("caf\xc3\xa9", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("-latte", input.buf.secondHalf());
+}
+
+test "deleteWordBefore with non-ASCII text" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("über-cool");
+    input.deleteWordBefore();
+    try std.testing.expectEqualStrings("über-", input.buf.firstHalf());
+    input.deleteWordBefore();
     try std.testing.expectEqualStrings("", input.buf.firstHalf());
 }
 

--- a/src/vxfw/TextField.zig
+++ b/src/vxfw/TextField.zig
@@ -96,8 +96,11 @@ pub fn handleEvent(self: *TextField, ctx: *vxfw.EventContext, event: vxfw.Event)
             } else if (key.matches('f', .{ .alt = true }) or key.matches(Key.right, .{ .alt = true })) {
                 self.moveForwardWordwise();
                 return ctx.consumeAndRedraw();
-            } else if (key.matches('w', .{ .ctrl = true }) or key.matches(Key.backspace, .{ .alt = true })) {
+            } else if (key.matches(Key.backspace, .{ .alt = true })) {
                 self.deleteWordBefore();
+                return self.checkChanged(ctx);
+            } else if (key.matches('w', .{ .ctrl = true })) {
+                self.deleteWordBeforeWhitespace();
                 return self.checkChanged(ctx);
             } else if (key.matches('d', .{ .alt = true })) {
                 self.deleteWordAfter();
@@ -343,41 +346,68 @@ pub fn deleteAfterCursor(self: *TextField) void {
     self.buf.growGapRight(grapheme.len);
 }
 
-/// Moves the cursor backward by words. If the character before the cursor is a space, the cursor is
-/// positioned just after the next previous space
-pub fn moveBackwardWordwise(self: *TextField) void {
-    const trimmed = std.mem.trimRight(u8, self.buf.firstHalf(), " ");
-    const idx = if (std.mem.lastIndexOfScalar(u8, trimmed, ' ')) |last|
-        last + 1
-    else
-        0;
-    self.buf.moveGapLeft(self.buf.cursor - idx);
+/// Returns true if the byte is a word constituent (alnum or underscore),
+/// matching readline/emacs word character classes.
+fn isWordChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '_';
 }
 
+/// Moves the cursor backward by one word using character-class boundaries.
+/// Skips non-word characters, then skips word characters (matching readline backward-word).
+pub fn moveBackwardWordwise(self: *TextField) void {
+    const first_half = self.buf.firstHalf();
+    var i: usize = first_half.len;
+    // Skip non-word characters
+    while (i > 0 and !isWordChar(first_half[i - 1])) : (i -= 1) {}
+    // Skip word characters
+    while (i > 0 and isWordChar(first_half[i - 1])) : (i -= 1) {}
+    self.buf.moveGapLeft(self.buf.cursor - i);
+}
+
+/// Moves the cursor forward by one word using character-class boundaries.
+/// Skips word characters, then skips non-word characters (matching readline forward-word).
 pub fn moveForwardWordwise(self: *TextField) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
-    while (i < second_half.len and second_half[i] == ' ') : (i += 1) {}
-    const idx = std.mem.indexOfScalarPos(u8, second_half, i, ' ') orelse second_half.len;
-    self.buf.moveGapRight(idx);
+    // Skip word characters
+    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    // Skip non-word characters
+    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    self.buf.moveGapRight(i);
 }
 
+/// Deletes the word before the cursor using character-class boundaries
+/// (matching readline backward-kill-word / Alt+Backspace).
 pub fn deleteWordBefore(self: *TextField) void {
-    // Store current cursor position. Move one word backward. Delete after the cursor the bytes we
-    // moved
     const pre = self.buf.cursor;
     self.moveBackwardWordwise();
     self.buf.growGapRight(pre - self.buf.cursor);
 }
 
+/// Deletes the word before the cursor using whitespace boundaries
+/// (matching readline unix-word-rubout / Ctrl+W).
+pub fn deleteWordBeforeWhitespace(self: *TextField) void {
+    const first_half = self.buf.firstHalf();
+    var i: usize = first_half.len;
+    // Skip trailing whitespace
+    while (i > 0 and std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    // Skip non-whitespace
+    while (i > 0 and !std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    const to_delete = self.buf.cursor - i;
+    self.buf.moveGapLeft(to_delete);
+    self.buf.growGapRight(to_delete);
+}
+
+/// Deletes the word after the cursor using character-class boundaries
+/// (matching readline kill-word / Alt+D).
 pub fn deleteWordAfter(self: *TextField) void {
-    // Store current cursor position. Move one word backward. Delete after the cursor the bytes we
-    // moved
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
-    while (i < second_half.len and second_half[i] == ' ') : (i += 1) {}
-    const idx = std.mem.indexOfScalarPos(u8, second_half, i, ' ') orelse second_half.len;
-    self.buf.growGapRight(idx);
+    // Skip non-word characters
+    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    // Skip word characters
+    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    self.buf.growGapRight(i);
 }
 
 test "sliceToCursor" {
@@ -591,6 +621,89 @@ test TextField {
 
     try tf_widget.handleEvent(&ctx, .{ .key_press = .{ .codepoint = '_', .text = "_" } });
     try std.testing.expectEqualStrings("Hell_o", foo.text);
+}
+
+test "moveBackwardWordwise stops at word boundary" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("hello-world", input.buf.secondHalf());
+}
+
+test "moveForwardWordwise stops at word boundary" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world");
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("hello-world", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("", input.buf.secondHalf());
+}
+
+test "moveBackwardWordwise with path separators" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("/usr/local/bin");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("/usr/local/", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("/usr/", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("/", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "deleteWordBefore with hyphens" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world");
+    input.deleteWordBefore();
+    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("", input.buf.secondHalf());
+    input.deleteWordBefore();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "deleteWordBeforeWhitespace deletes to whitespace" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world foo.bar");
+    input.deleteWordBeforeWhitespace();
+    try std.testing.expectEqualStrings("hello-world ", input.buf.firstHalf());
+    input.deleteWordBeforeWhitespace();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "deleteWordAfter with mixed punctuation" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("foo.bar baz");
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    input.deleteWordAfter();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings(".bar baz", input.buf.secondHalf());
+    input.deleteWordAfter();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings(" baz", input.buf.secondHalf());
+}
+
+test "word motion with underscores treats them as word chars" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello_world-test");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("hello_world-", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
 }
 
 test "refAllDecls" {

--- a/src/vxfw/TextField.zig
+++ b/src/vxfw/TextField.zig
@@ -365,14 +365,15 @@ pub fn moveBackwardWordwise(self: *TextField) void {
 }
 
 /// Moves the cursor forward by one word using character-class boundaries.
-/// Skips word characters, then skips non-word characters (matching readline forward-word).
+/// Skips non-word characters, then skips word characters — landing at the end of the next word
+/// (matching readline forward-word).
 pub fn moveForwardWordwise(self: *TextField) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
-    // Skip word characters
-    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
     // Skip non-word characters
     while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    // Skip word characters
+    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
     self.buf.moveGapRight(i);
 }
 
@@ -635,15 +636,17 @@ test "moveBackwardWordwise stops at word boundary" {
     try std.testing.expectEqualStrings("hello-world", input.buf.secondHalf());
 }
 
-test "moveForwardWordwise stops at word boundary" {
+test "moveForwardWordwise stops at end of word" {
     var input = TextField.init(std.testing.allocator);
     defer input.deinit();
     try input.insertSliceAtCursor("hello-world");
     input.buf.moveGapLeft(input.buf.firstHalf().len);
     input.moveForwardWordwise();
-    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
-    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+    // Stops at end of "hello": "hello|-world"
+    try std.testing.expectEqualStrings("hello", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("-world", input.buf.secondHalf());
     input.moveForwardWordwise();
+    // Skips "-" then stops at end of "world": "hello-world|"
     try std.testing.expectEqualStrings("hello-world", input.buf.firstHalf());
     try std.testing.expectEqualStrings("", input.buf.secondHalf());
 }
@@ -696,12 +699,35 @@ test "deleteWordAfter with mixed punctuation" {
     try std.testing.expectEqualStrings(" baz", input.buf.secondHalf());
 }
 
+test "moveForwardWordwise with dots" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("foo.bar.baz");
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("foo", input.buf.firstHalf());
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("foo.bar", input.buf.firstHalf());
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("foo.bar.baz", input.buf.firstHalf());
+}
+
 test "word motion with underscores treats them as word chars" {
     var input = TextField.init(std.testing.allocator);
     defer input.deinit();
     try input.insertSliceAtCursor("hello_world-test");
     input.moveBackwardWordwise();
     try std.testing.expectEqualStrings("hello_world-", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "word motion with spaces" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello world");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("hello ", input.buf.firstHalf());
     input.moveBackwardWordwise();
     try std.testing.expectEqualStrings("", input.buf.firstHalf());
 }

--- a/src/vxfw/TextField.zig
+++ b/src/vxfw/TextField.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const uucode = @import("uucode");
 const vaxis = @import("../main.zig");
 
 const vxfw = @import("vxfw.zig");
@@ -346,11 +347,69 @@ pub fn deleteAfterCursor(self: *TextField) void {
     self.buf.growGapRight(grapheme.len);
 }
 
-/// Returns true if the byte is a word constituent: ASCII alnum, underscore,
-/// or any non-ASCII byte (part of a multi-byte UTF-8 sequence). This ensures
-/// word motion never splits inside non-ASCII characters like accented letters.
-fn isWordChar(c: u8) bool {
-    return std.ascii.isAlphanumeric(c) or c == '_' or c >= 0x80;
+const DecodedCodepoint = struct {
+    cp: u21,
+    start: usize,
+    len: usize,
+};
+
+fn decodeCodepointAt(bytes: []const u8, start: usize) DecodedCodepoint {
+    const first = bytes[start];
+    const len = std.unicode.utf8ByteSequenceLength(first) catch 1;
+    const capped_len = @min(len, bytes.len - start);
+    const slice = bytes[start .. start + capped_len];
+    const cp = std.unicode.utf8Decode(slice) catch {
+        return .{ .cp = first, .start = start, .len = 1 };
+    };
+    return .{ .cp = cp, .start = start, .len = capped_len };
+}
+
+fn isUtf8ContinuationByte(c: u8) bool {
+    return (c & 0b1100_0000) == 0b1000_0000;
+}
+
+fn decodeCodepointBefore(bytes: []const u8, end: usize) DecodedCodepoint {
+    var start = end - 1;
+    while (start > 0 and isUtf8ContinuationByte(bytes[start])) : (start -= 1) {}
+    const slice = bytes[start..end];
+    const cp = std.unicode.utf8Decode(slice) catch {
+        return .{ .cp = bytes[end - 1], .start = end - 1, .len = 1 };
+    };
+    return .{ .cp = cp, .start = start, .len = end - start };
+}
+
+/// Returns true if the codepoint is a readline-style word constituent.
+fn isWordCodepoint(cp: u21) bool {
+    if (cp == '_') return true;
+    return switch (uucode.get(.general_category, cp)) {
+        .letter_uppercase,
+        .letter_lowercase,
+        .letter_titlecase,
+        .letter_modifier,
+        .letter_other,
+        .number_decimal_digit,
+        .number_letter,
+        .number_other,
+        .mark_nonspacing,
+        .mark_spacing_combining,
+        .mark_enclosing,
+        .punctuation_connector,
+        => true,
+        else => false,
+    };
+}
+
+fn isWhitespaceCodepoint(cp: u21) bool {
+    return switch (cp) {
+        ' ', '\t', '\n', '\r', 0x0b, 0x0c, 0x85 => true,
+        else => switch (uucode.get(.general_category, cp)) {
+            .separator_space,
+            .separator_line,
+            .separator_paragraph,
+            => true,
+            else => false,
+        },
+    };
 }
 
 /// Moves the cursor backward by one word using character-class boundaries.
@@ -359,9 +418,17 @@ pub fn moveBackwardWordwise(self: *TextField) void {
     const first_half = self.buf.firstHalf();
     var i: usize = first_half.len;
     // Skip non-word characters
-    while (i > 0 and !isWordChar(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (isWordCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     // Skip word characters
-    while (i > 0 and isWordChar(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (!isWordCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     self.buf.moveGapLeft(self.buf.cursor - i);
 }
 
@@ -372,9 +439,17 @@ pub fn moveForwardWordwise(self: *TextField) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
     // Skip non-word characters
-    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     // Skip word characters
-    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (!isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     self.buf.moveGapRight(i);
 }
 
@@ -392,9 +467,17 @@ pub fn deleteWordBeforeWhitespace(self: *TextField) void {
     const first_half = self.buf.firstHalf();
     var i: usize = first_half.len;
     // Skip trailing whitespace
-    while (i > 0 and std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (!isWhitespaceCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     // Skip non-whitespace
-    while (i > 0 and !std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (isWhitespaceCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     const to_delete = self.buf.cursor - i;
     self.buf.moveGapLeft(to_delete);
     self.buf.growGapRight(to_delete);
@@ -406,9 +489,17 @@ pub fn deleteWordAfter(self: *TextField) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
     // Skip non-word characters
-    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     // Skip word characters
-    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (!isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     self.buf.growGapRight(i);
 }
 
@@ -738,16 +829,27 @@ test "word motion with non-ASCII text" {
     try std.testing.expectEqualStrings("-latte", input.buf.secondHalf());
 }
 
-test "non-ASCII punctuation treated as word chars" {
+test "non-ASCII punctuation acts as a separator" {
     var input = TextField.init(std.testing.allocator);
     defer input.deinit();
-    // Em dash (U+2014, 3 bytes: E2 80 94) has bytes >= 0x80, so all bytes are
-    // classified as word chars. The entire string is one continuous "word" — the
-    // em dash does NOT act as a separator. This is a known limitation of the
-    // byte-based classifier.
-    try input.insertSliceAtCursor("hello\xe2\x80\x94world");
+    try input.insertSliceAtCursor("hello\u{2014}world");
     input.moveBackwardWordwise();
-    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("hello\u{2014}", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("hello", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("\u{2014}world", input.buf.secondHalf());
+}
+
+test "deleteWordBeforeWhitespace handles unicode whitespace" {
+    var input = TextField.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello\u{3000}world");
+    input.deleteWordBeforeWhitespace();
+    try std.testing.expectEqualStrings("hello\u{3000}", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("", input.buf.secondHalf());
 }
 
 test "deleteWordBefore with non-ASCII text" {

--- a/src/widgets/TextInput.zig
+++ b/src/widgets/TextInput.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const uucode = @import("uucode");
 const assert = std.debug.assert;
 const Key = @import("../Key.zig");
 const Cell = @import("../Cell.zig");
@@ -265,11 +266,69 @@ pub fn deleteAfterCursor(self: *TextInput) void {
     self.buf.growGapRight(grapheme.len);
 }
 
-/// Returns true if the byte is a word constituent: ASCII alnum, underscore,
-/// or any non-ASCII byte (part of a multi-byte UTF-8 sequence). This ensures
-/// word motion never splits inside non-ASCII characters like accented letters.
-fn isWordChar(c: u8) bool {
-    return std.ascii.isAlphanumeric(c) or c == '_' or c >= 0x80;
+const DecodedCodepoint = struct {
+    cp: u21,
+    start: usize,
+    len: usize,
+};
+
+fn decodeCodepointAt(bytes: []const u8, start: usize) DecodedCodepoint {
+    const first = bytes[start];
+    const len = std.unicode.utf8ByteSequenceLength(first) catch 1;
+    const capped_len = @min(len, bytes.len - start);
+    const slice = bytes[start .. start + capped_len];
+    const cp = std.unicode.utf8Decode(slice) catch {
+        return .{ .cp = first, .start = start, .len = 1 };
+    };
+    return .{ .cp = cp, .start = start, .len = capped_len };
+}
+
+fn isUtf8ContinuationByte(c: u8) bool {
+    return (c & 0b1100_0000) == 0b1000_0000;
+}
+
+fn decodeCodepointBefore(bytes: []const u8, end: usize) DecodedCodepoint {
+    var start = end - 1;
+    while (start > 0 and isUtf8ContinuationByte(bytes[start])) : (start -= 1) {}
+    const slice = bytes[start..end];
+    const cp = std.unicode.utf8Decode(slice) catch {
+        return .{ .cp = bytes[end - 1], .start = end - 1, .len = 1 };
+    };
+    return .{ .cp = cp, .start = start, .len = end - start };
+}
+
+/// Returns true if the codepoint is a readline-style word constituent.
+fn isWordCodepoint(cp: u21) bool {
+    if (cp == '_') return true;
+    return switch (uucode.get(.general_category, cp)) {
+        .letter_uppercase,
+        .letter_lowercase,
+        .letter_titlecase,
+        .letter_modifier,
+        .letter_other,
+        .number_decimal_digit,
+        .number_letter,
+        .number_other,
+        .mark_nonspacing,
+        .mark_spacing_combining,
+        .mark_enclosing,
+        .punctuation_connector,
+        => true,
+        else => false,
+    };
+}
+
+fn isWhitespaceCodepoint(cp: u21) bool {
+    return switch (cp) {
+        ' ', '\t', '\n', '\r', 0x0b, 0x0c, 0x85 => true,
+        else => switch (uucode.get(.general_category, cp)) {
+            .separator_space,
+            .separator_line,
+            .separator_paragraph,
+            => true,
+            else => false,
+        },
+    };
 }
 
 /// Moves the cursor backward by one word using character-class boundaries.
@@ -278,9 +337,17 @@ pub fn moveBackwardWordwise(self: *TextInput) void {
     const first_half = self.buf.firstHalf();
     var i: usize = first_half.len;
     // Skip non-word characters
-    while (i > 0 and !isWordChar(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (isWordCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     // Skip word characters
-    while (i > 0 and isWordChar(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (!isWordCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     self.buf.moveGapLeft(self.buf.cursor - i);
 }
 
@@ -291,9 +358,17 @@ pub fn moveForwardWordwise(self: *TextInput) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
     // Skip non-word characters
-    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     // Skip word characters
-    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (!isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     self.buf.moveGapRight(i);
 }
 
@@ -311,9 +386,17 @@ pub fn deleteWordBeforeWhitespace(self: *TextInput) void {
     const first_half = self.buf.firstHalf();
     var i: usize = first_half.len;
     // Skip trailing whitespace
-    while (i > 0 and std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (!isWhitespaceCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     // Skip non-whitespace
-    while (i > 0 and !std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    while (i > 0) {
+        const decoded = decodeCodepointBefore(first_half, i);
+        if (isWhitespaceCodepoint(decoded.cp)) break;
+        i = decoded.start;
+    }
     const to_delete = self.buf.cursor - i;
     self.buf.moveGapLeft(to_delete);
     self.buf.growGapRight(to_delete);
@@ -325,9 +408,17 @@ pub fn deleteWordAfter(self: *TextInput) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
     // Skip non-word characters
-    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     // Skip word characters
-    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    while (i < second_half.len) {
+        const decoded = decodeCodepointAt(second_half, i);
+        if (!isWordCodepoint(decoded.cp)) break;
+        i += decoded.len;
+    }
     self.buf.growGapRight(i);
 }
 
@@ -595,17 +686,27 @@ test "word motion with non-ASCII text" {
     try std.testing.expectEqualStrings("-latte", input.buf.secondHalf());
 }
 
-test "non-ASCII punctuation treated as word chars" {
+test "non-ASCII punctuation acts as a separator" {
     var input = TextInput.init(std.testing.allocator);
     defer input.deinit();
-    // Em dash (U+2014, 3 bytes: E2 80 94) has bytes >= 0x80, so all bytes are
-    // classified as word chars. The entire string is one continuous "word" — the
-    // em dash does NOT act as a separator. This is a known limitation of the
-    // byte-based classifier; proper Unicode category classification would be
-    // needed to treat non-ASCII punctuation as separators.
-    try input.insertSliceAtCursor("hello\xe2\x80\x94world");
+    try input.insertSliceAtCursor("hello\u{2014}world");
     input.moveBackwardWordwise();
-    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("hello\u{2014}", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("hello", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("\u{2014}world", input.buf.secondHalf());
+}
+
+test "deleteWordBeforeWhitespace handles unicode whitespace" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello\u{3000}world");
+    input.deleteWordBeforeWhitespace();
+    try std.testing.expectEqualStrings("hello\u{3000}", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("", input.buf.secondHalf());
 }
 
 test "deleteWordBefore with non-ASCII text" {

--- a/src/widgets/TextInput.zig
+++ b/src/widgets/TextInput.zig
@@ -265,10 +265,11 @@ pub fn deleteAfterCursor(self: *TextInput) void {
     self.buf.growGapRight(grapheme.len);
 }
 
-/// Returns true if the byte is a word constituent (alnum or underscore),
-/// matching readline/emacs word character classes.
+/// Returns true if the byte is a word constituent: ASCII alnum, underscore,
+/// or any non-ASCII byte (part of a multi-byte UTF-8 sequence). This ensures
+/// word motion never splits inside non-ASCII characters like accented letters.
 fn isWordChar(c: u8) bool {
-    return std.ascii.isAlphanumeric(c) or c == '_';
+    return std.ascii.isAlphanumeric(c) or c == '_' or c >= 0x80;
 }
 
 /// Moves the cursor backward by one word using character-class boundaries.
@@ -573,6 +574,34 @@ test "word motion with underscores treats them as word chars" {
     try std.testing.expectEqualStrings("hello_world-", input.buf.firstHalf());
     input.moveBackwardWordwise();
     // "hello_world" is one word (underscore is word char): "|hello_world-test"
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "word motion with non-ASCII text" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    // "café-latte" — the é is multi-byte UTF-8, should not split inside it
+    try input.insertSliceAtCursor("café-latte");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("café-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("latte", input.buf.secondHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+
+    // Forward from start
+    input.moveForwardWordwise();
+    // Should stop at end of "café"
+    try std.testing.expectEqualStrings("caf\xc3\xa9", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("-latte", input.buf.secondHalf());
+}
+
+test "deleteWordBefore with non-ASCII text" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("über-cool");
+    input.deleteWordBefore();
+    try std.testing.expectEqualStrings("über-", input.buf.firstHalf());
+    input.deleteWordBefore();
     try std.testing.expectEqualStrings("", input.buf.firstHalf());
 }
 

--- a/src/widgets/TextInput.zig
+++ b/src/widgets/TextInput.zig
@@ -284,14 +284,15 @@ pub fn moveBackwardWordwise(self: *TextInput) void {
 }
 
 /// Moves the cursor forward by one word using character-class boundaries.
-/// Skips word characters, then skips non-word characters (matching readline forward-word).
+/// Skips non-word characters, then skips word characters — landing at the end of the next word
+/// (matching readline forward-word).
 pub fn moveForwardWordwise(self: *TextInput) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
-    // Skip word characters
-    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
     // Skip non-word characters
     while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    // Skip word characters
+    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
     self.buf.moveGapRight(i);
 }
 
@@ -476,7 +477,7 @@ test "moveBackwardWordwise stops at word boundary" {
     try std.testing.expectEqualStrings("hello-world", input.buf.secondHalf());
 }
 
-test "moveForwardWordwise stops at word boundary" {
+test "moveForwardWordwise stops at end of word" {
     var input = TextInput.init(std.testing.allocator);
     defer input.deinit();
     try input.insertSliceAtCursor("hello-world");
@@ -484,11 +485,11 @@ test "moveForwardWordwise stops at word boundary" {
     input.buf.moveGapLeft(input.buf.firstHalf().len);
     // Cursor at start: "|hello-world"
     input.moveForwardWordwise();
-    // Should skip "hello" then "-": "hello-|world"
-    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
-    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+    // Should stop at end of "hello": "hello|-world"
+    try std.testing.expectEqualStrings("hello", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("-world", input.buf.secondHalf());
     input.moveForwardWordwise();
-    // Should skip "world" to end: "hello-world|"
+    // Should skip "-" then stop at end of "world": "hello-world|"
     try std.testing.expectEqualStrings("hello-world", input.buf.firstHalf());
     try std.testing.expectEqualStrings("", input.buf.secondHalf());
 }
@@ -513,10 +514,13 @@ test "moveForwardWordwise with dots" {
     try input.insertSliceAtCursor("foo.bar.baz");
     input.buf.moveGapLeft(input.buf.firstHalf().len);
     input.moveForwardWordwise();
-    try std.testing.expectEqualStrings("foo.", input.buf.firstHalf());
+    // Stops at end of "foo": "foo|.bar.baz"
+    try std.testing.expectEqualStrings("foo", input.buf.firstHalf());
     input.moveForwardWordwise();
-    try std.testing.expectEqualStrings("foo.bar.", input.buf.firstHalf());
+    // Skips "." then stops at end of "bar": "foo.bar|.baz"
+    try std.testing.expectEqualStrings("foo.bar", input.buf.firstHalf());
     input.moveForwardWordwise();
+    // Skips "." then stops at end of "baz": "foo.bar.baz|"
     try std.testing.expectEqualStrings("foo.bar.baz", input.buf.firstHalf());
 }
 
@@ -550,19 +554,12 @@ test "deleteWordAfter with mixed punctuation" {
     defer input.deinit();
     try input.insertSliceAtCursor("foo.bar baz");
     input.buf.moveGapLeft(input.buf.firstHalf().len);
-    // Cursor at start: "|foo.bar baz"
     input.deleteWordAfter();
-    // Should delete "foo" then ".": ".bar baz" — wait, readline kill-word skips non-word then word
-    // Actually: skip non-word (none at start), skip word "foo" = delete "foo"
-    // No: kill-word skips word chars first, then non-word chars? Let me think...
-    // readline forward-kill-word: delete forward to end of next word
-    // From "|foo.bar": delete "foo" (word chars), then "." (non-word chars) = "foo."
-    // Actually no. readline kill-word: skip non-word, then skip word. Same as our deleteWordAfter.
-    // From "|foo.bar": no non-word to skip, then skip "foo" = delete "foo" leaving ".bar baz"
+    // kill-word: skip non-word (none), skip word "foo" → delete "foo"
     try std.testing.expectEqualStrings("", input.buf.firstHalf());
     try std.testing.expectEqualStrings(".bar baz", input.buf.secondHalf());
     input.deleteWordAfter();
-    // From "|.bar baz": skip "." (non-word), then skip "bar" (word) = delete ".bar"
+    // kill-word: skip "." (non-word), skip "bar" (word) → delete ".bar"
     try std.testing.expectEqualStrings("", input.buf.firstHalf());
     try std.testing.expectEqualStrings(" baz", input.buf.secondHalf());
 }

--- a/src/widgets/TextInput.zig
+++ b/src/widgets/TextInput.zig
@@ -59,8 +59,10 @@ pub fn update(self: *TextInput, event: Event) !void {
                 self.moveBackwardWordwise();
             } else if (key.matches('f', .{ .alt = true }) or key.matches(Key.right, .{ .alt = true })) {
                 self.moveForwardWordwise();
-            } else if (key.matches('w', .{ .ctrl = true }) or key.matches(Key.backspace, .{ .alt = true })) {
+            } else if (key.matches(Key.backspace, .{ .alt = true })) {
                 self.deleteWordBefore();
+            } else if (key.matches('w', .{ .ctrl = true })) {
+                self.deleteWordBeforeWhitespace();
             } else if (key.matches('d', .{ .alt = true })) {
                 self.deleteWordAfter();
             } else if (key.text) |text| {
@@ -263,41 +265,68 @@ pub fn deleteAfterCursor(self: *TextInput) void {
     self.buf.growGapRight(grapheme.len);
 }
 
-/// Moves the cursor backward by words. If the character before the cursor is a space, the cursor is
-/// positioned just after the next previous space
-pub fn moveBackwardWordwise(self: *TextInput) void {
-    const trimmed = std.mem.trimRight(u8, self.buf.firstHalf(), " ");
-    const idx = if (std.mem.lastIndexOfScalar(u8, trimmed, ' ')) |last|
-        last + 1
-    else
-        0;
-    self.buf.moveGapLeft(self.buf.cursor - idx);
+/// Returns true if the byte is a word constituent (alnum or underscore),
+/// matching readline/emacs word character classes.
+fn isWordChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '_';
 }
 
+/// Moves the cursor backward by one word using character-class boundaries.
+/// Skips non-word characters, then skips word characters (matching readline backward-word).
+pub fn moveBackwardWordwise(self: *TextInput) void {
+    const first_half = self.buf.firstHalf();
+    var i: usize = first_half.len;
+    // Skip non-word characters
+    while (i > 0 and !isWordChar(first_half[i - 1])) : (i -= 1) {}
+    // Skip word characters
+    while (i > 0 and isWordChar(first_half[i - 1])) : (i -= 1) {}
+    self.buf.moveGapLeft(self.buf.cursor - i);
+}
+
+/// Moves the cursor forward by one word using character-class boundaries.
+/// Skips word characters, then skips non-word characters (matching readline forward-word).
 pub fn moveForwardWordwise(self: *TextInput) void {
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
-    while (i < second_half.len and second_half[i] == ' ') : (i += 1) {}
-    const idx = std.mem.indexOfScalarPos(u8, second_half, i, ' ') orelse second_half.len;
-    self.buf.moveGapRight(idx);
+    // Skip word characters
+    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    // Skip non-word characters
+    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    self.buf.moveGapRight(i);
 }
 
+/// Deletes the word before the cursor using character-class boundaries
+/// (matching readline backward-kill-word / Alt+Backspace).
 pub fn deleteWordBefore(self: *TextInput) void {
-    // Store current cursor position. Move one word backward. Delete after the cursor the bytes we
-    // moved
     const pre = self.buf.cursor;
     self.moveBackwardWordwise();
     self.buf.growGapRight(pre - self.buf.cursor);
 }
 
+/// Deletes the word before the cursor using whitespace boundaries
+/// (matching readline unix-word-rubout / Ctrl+W).
+pub fn deleteWordBeforeWhitespace(self: *TextInput) void {
+    const first_half = self.buf.firstHalf();
+    var i: usize = first_half.len;
+    // Skip trailing whitespace
+    while (i > 0 and std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    // Skip non-whitespace
+    while (i > 0 and !std.ascii.isWhitespace(first_half[i - 1])) : (i -= 1) {}
+    const to_delete = self.buf.cursor - i;
+    self.buf.moveGapLeft(to_delete);
+    self.buf.growGapRight(to_delete);
+}
+
+/// Deletes the word after the cursor using character-class boundaries
+/// (matching readline kill-word / Alt+D).
 pub fn deleteWordAfter(self: *TextInput) void {
-    // Store current cursor position. Move one word backward. Delete after the cursor the bytes we
-    // moved
     const second_half = self.buf.secondHalf();
     var i: usize = 0;
-    while (i < second_half.len and second_half[i] == ' ') : (i += 1) {}
-    const idx = std.mem.indexOfScalarPos(u8, second_half, i, ' ') orelse second_half.len;
-    self.buf.growGapRight(idx);
+    // Skip non-word characters
+    while (i < second_half.len and !isWordChar(second_half[i])) : (i += 1) {}
+    // Skip word characters
+    while (i < second_half.len and isWordChar(second_half[i])) : (i += 1) {}
+    self.buf.growGapRight(i);
 }
 
 test "assertion" {
@@ -431,6 +460,134 @@ pub const Buffer = struct {
         return self.firstHalf().len + self.secondHalf().len;
     }
 };
+
+test "moveBackwardWordwise stops at word boundary" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world");
+    // Cursor is at end: "hello-world|"
+    input.moveBackwardWordwise();
+    // Should stop at start of "world": "hello-|world"
+    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+    input.moveBackwardWordwise();
+    // Should skip "-" and stop at start of "hello": "|hello-world"
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("hello-world", input.buf.secondHalf());
+}
+
+test "moveForwardWordwise stops at word boundary" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world");
+    // Move cursor to start
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    // Cursor at start: "|hello-world"
+    input.moveForwardWordwise();
+    // Should skip "hello" then "-": "hello-|world"
+    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("world", input.buf.secondHalf());
+    input.moveForwardWordwise();
+    // Should skip "world" to end: "hello-world|"
+    try std.testing.expectEqualStrings("hello-world", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("", input.buf.secondHalf());
+}
+
+test "moveBackwardWordwise with path separators" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("/usr/local/bin");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("/usr/local/", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("/usr/", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("/", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "moveForwardWordwise with dots" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("foo.bar.baz");
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("foo.", input.buf.firstHalf());
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("foo.bar.", input.buf.firstHalf());
+    input.moveForwardWordwise();
+    try std.testing.expectEqualStrings("foo.bar.baz", input.buf.firstHalf());
+}
+
+test "deleteWordBefore with hyphens" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world");
+    input.deleteWordBefore();
+    // Should delete "world" only: "hello-|"
+    try std.testing.expectEqualStrings("hello-", input.buf.firstHalf());
+    try std.testing.expectEqualStrings("", input.buf.secondHalf());
+    input.deleteWordBefore();
+    // Should skip "-" and delete "hello": "|"
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "deleteWordBeforeWhitespace deletes to whitespace" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello-world foo.bar");
+    input.deleteWordBeforeWhitespace();
+    // Should delete "foo.bar" (entire whitespace-delimited word)
+    try std.testing.expectEqualStrings("hello-world ", input.buf.firstHalf());
+    input.deleteWordBeforeWhitespace();
+    // Should delete " hello-world"
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "deleteWordAfter with mixed punctuation" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("foo.bar baz");
+    input.buf.moveGapLeft(input.buf.firstHalf().len);
+    // Cursor at start: "|foo.bar baz"
+    input.deleteWordAfter();
+    // Should delete "foo" then ".": ".bar baz" — wait, readline kill-word skips non-word then word
+    // Actually: skip non-word (none at start), skip word "foo" = delete "foo"
+    // No: kill-word skips word chars first, then non-word chars? Let me think...
+    // readline forward-kill-word: delete forward to end of next word
+    // From "|foo.bar": delete "foo" (word chars), then "." (non-word chars) = "foo."
+    // Actually no. readline kill-word: skip non-word, then skip word. Same as our deleteWordAfter.
+    // From "|foo.bar": no non-word to skip, then skip "foo" = delete "foo" leaving ".bar baz"
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings(".bar baz", input.buf.secondHalf());
+    input.deleteWordAfter();
+    // From "|.bar baz": skip "." (non-word), then skip "bar" (word) = delete ".bar"
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+    try std.testing.expectEqualStrings(" baz", input.buf.secondHalf());
+}
+
+test "word motion with underscores treats them as word chars" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello_world-test");
+    input.moveBackwardWordwise();
+    // "test" is a word, should stop before it: "hello_world-|test"
+    try std.testing.expectEqualStrings("hello_world-", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    // "hello_world" is one word (underscore is word char): "|hello_world-test"
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
+test "word motion with spaces" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    try input.insertSliceAtCursor("hello world");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("hello ", input.buf.firstHalf());
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
 
 test "TextInput.zig: Buffer" {
     var gap_buf = Buffer.init(std.testing.allocator);

--- a/src/widgets/TextInput.zig
+++ b/src/widgets/TextInput.zig
@@ -595,6 +595,19 @@ test "word motion with non-ASCII text" {
     try std.testing.expectEqualStrings("-latte", input.buf.secondHalf());
 }
 
+test "non-ASCII punctuation treated as word chars" {
+    var input = TextInput.init(std.testing.allocator);
+    defer input.deinit();
+    // Em dash (U+2014, 3 bytes: E2 80 94) has bytes >= 0x80, so all bytes are
+    // classified as word chars. The entire string is one continuous "word" — the
+    // em dash does NOT act as a separator. This is a known limitation of the
+    // byte-based classifier; proper Unicode category classification would be
+    // needed to treat non-ASCII punctuation as separators.
+    try input.insertSliceAtCursor("hello\xe2\x80\x94world");
+    input.moveBackwardWordwise();
+    try std.testing.expectEqualStrings("", input.buf.firstHalf());
+}
+
 test "deleteWordBefore with non-ASCII text" {
     var input = TextInput.init(std.testing.allocator);
     defer input.deinit();


### PR DESCRIPTION
Word motion (`Alt+B`/`Alt+F`) and word deletion (`Alt+Backspace`, `Alt+D`) now use character-class boundaries instead of space-only, matching readline behavior. `Ctrl+W` is split into its own whitespace-delimited code path (`unix-word-rubout`). Non-ASCII bytes are treated as word characters to avoid splitting inside UTF-8 sequences.

Context and analysis: https://gist.github.com/possibilities/1363553e2257692624cf54e64f8f5255