### PR TITLE
deps: add external_uucode option to use externally provided uucode

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,41 @@ or for ZLS support
     // install exe below
 ```
 
+#### Sharing `uucode` with your application
+
+By default, libvaxis pulls in [`uucode`](https://github.com/jacobsandlund/uucode)
+with a fixed set of fields it needs (`east_asian_width`, `grapheme_break`,
+`general_category`, `is_emoji_presentation`). If your application also uses
+`uucode` and needs additional fields, you can build libvaxis against your own
+`uucode` module so that everyone shares one table.
+
+Pass `.external_uucode = true` to the libvaxis dependency and wire your
+`uucode` module into the `vaxis` module yourself:
+
+```zig
+    const uucode = b.dependency("uucode", .{
+        .target = target,
+        .optimize = optimize,
+        .fields = @as([]const []const u8, &.{
+            // Add any fields your application needs, plus the fields libvaxis
+            // requires. The compiler will tell you which fields are missing
+            // (you only need the libvaxis fields for the parts of libvaxis you
+            // actually use). See `build.zig` in libvaxis for the full set it
+            // uses internally.
+        }),
+    });
+
+    const vaxis = b.dependency("vaxis", .{
+        .target = target,
+        .optimize = optimize,
+        .external_uucode = true,
+    });
+    vaxis.module("vaxis").addImport("uucode", uucode.module("uucode"));
+
+    exe.root_module.addImport("vaxis", vaxis.module("vaxis"));
+    exe.root_module.addImport("uucode", uucode.module("uucode"));
+```
+
 ### vxfw (Vaxis framework)
 
 Let's build a simple button counter application. This example can be run using

--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ or for ZLS support
 
 #### Sharing `uucode` with your application
 
-By default, libvaxis pulls in [`uucode`](https://github.com/jacobsandlund/uucode)
-with a fixed set of fields it needs (`east_asian_width`, `grapheme_break`,
-`general_category`, `is_emoji_presentation`). If your application also uses
-`uucode` and needs additional fields, you can build libvaxis against your own
-`uucode` module so that everyone shares one table.
+By default, libvaxis pulls in
+[`uucode`](https://github.com/jacobsandlund/uucode) with a fixed set of fields
+it needs (see [build.zig](./build.zig)). If your application also uses
+`uucode`, you can build libvaxis against your own `uucode` module so that
+everyone shares one table (or set of tables, based on your `uucode`
+configuration).
 
 Pass `.external_uucode = true` to the libvaxis dependency and wire your
 `uucode` module into the `vaxis` module yourself:

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const use_llvm = b.option(bool, "llvm", "Use the LLVM backend for compile steps") orelse true;
+    const external_uucode = b.option(bool, "external_uucode", "Use an externally provided uucode module instead of the built-in dependency") orelse false;
     const root_source_file = b.path("src/main.zig");
 
     // Dependencies
@@ -11,16 +12,19 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .target = target,
     });
-    const uucode_dep = b.dependency("uucode", .{
-        .target = target,
-        .optimize = optimize,
-        .fields = @as([]const []const u8, &.{
-            "east_asian_width",
-            "grapheme_break",
-            "general_category",
-            "is_emoji_presentation",
-        }),
-    });
+    const uucode_mod = if (!external_uucode) blk: {
+        const uucode_dep = b.lazyDependency("uucode", .{
+            .target = target,
+            .optimize = optimize,
+            .fields = @as([]const []const u8, &.{
+                "east_asian_width",
+                "grapheme_break",
+                "general_category",
+                "is_emoji_presentation",
+            }),
+        }) orelse break :blk null;
+        break :blk uucode_dep.module("uucode");
+    } else null;
 
     // Module
     const vaxis_mod = b.addModule("vaxis", .{
@@ -29,7 +33,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
     vaxis_mod.addImport("zigimg", zigimg_dep.module("zigimg"));
-    vaxis_mod.addImport("uucode", uucode_dep.module("uucode"));
+    if (uucode_mod) |mod| {
+        vaxis_mod.addImport("uucode", mod);
+    }
 
     // Examples
     const Example = enum {
@@ -107,10 +113,15 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
-            .imports = &.{
-                .{ .name = "zigimg", .module = zigimg_dep.module("zigimg") },
-                .{ .name = "uucode", .module = uucode_dep.module("uucode") },
-            },
+            .imports = if (uucode_mod) |mod|
+                &.{
+                    .{ .name = "zigimg", .module = zigimg_dep.module("zigimg") },
+                    .{ .name = "uucode", .module = mod },
+                }
+            else
+                &.{
+                    .{ .name = "zigimg", .module = zigimg_dep.module("zigimg") },
+                },
         }),
     });
 

--- a/build.zig
+++ b/build.zig
@@ -35,6 +35,11 @@ pub fn build(b: *std.Build) void {
     vaxis_mod.addImport("zigimg", zigimg_dep.module("zigimg"));
     if (uucode_mod) |mod| {
         vaxis_mod.addImport("uucode", mod);
+    } else {
+        // External uucode mode: consumer wires up their own uucode module on
+        // the vaxis module. Skip examples, bench, tests, and docs steps since
+        // they all depend on uucode being available here.
+        return;
     }
 
     // Examples
@@ -113,15 +118,10 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/main.zig"),
             .target = target,
             .optimize = optimize,
-            .imports = if (uucode_mod) |mod|
-                &.{
-                    .{ .name = "zigimg", .module = zigimg_dep.module("zigimg") },
-                    .{ .name = "uucode", .module = mod },
-                }
-            else
-                &.{
-                    .{ .name = "zigimg", .module = zigimg_dep.module("zigimg") },
-                },
+            .imports = &.{
+                .{ .name = "zigimg", .module = zigimg_dep.module("zigimg") },
+                .{ .name = "uucode", .module = uucode_mod.? },
+            },
         }),
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,6 +11,7 @@
         .uucode = .{
             .url = "git+https://github.com/jacobsandlund/uucode#2826a37a4562284fdacd8fa029d49509cc9bffcd",
             .hash = "uucode-0.2.0-ZZjBPlK5VADj7fdoq7G8LIHzD5o6FSkcBXXrRWr4jnrA",
+            .lazy = true,
         },
     },
     .paths = .{


### PR DESCRIPTION
This PR adds an `external_uucode` option to allow users to pass their own copy of `uucode` in to `libvaxis`, which allows them to re-use the same tables from their own app, and even possibly cut down on the table size that libvaxis needs if they only partially use libvaxis.

See the additions to the README.

With the help of Amp: https://ampcode.com/threads/T-019dca19-d1e0-733f-b835-ebb24b1ea545