### PR TITLE
fix: use ArrayList.empty instead of {}.

### DIFF
--- a/src/widgets/Table.zig
+++ b/src/widgets/Table.zig
@@ -170,7 +170,7 @@ pub fn drawTable(
                         const fn_info = @typeInfo(@TypeOf(@field(@TypeOf(mal_slice), "get")));
                         break :dataType fn_info.@"fn".return_type orelse @panic("No Child Type");
                     };
-                    var data_out_list = std.ArrayList(DataT){};
+                    var data_out_list = std.ArrayList(DataT).empty;
                     for (0..mal_slice.len) |idx| try data_out_list.append(_alloc, mal_slice.get(idx));
                     break :getData try data_out_list.toOwnedSlice(_alloc);
                 }


### PR DESCRIPTION
default intialization of ArrayList() changed to .empty.