### PR TITLE
ci: use Zig 0.16 for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
         with:
-          version: 0.15.1
+          version: 0.16.0
       - run: zig build docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
The docs workflow was still installing Zig 0.15.1, while the current uucode dependency build script expects Zig 0.16's Build API. This matches the test workflow's Zig version and fixes the recurring docs deploy failure.\n\nVerified locally with:\n\n```sh\nzig build docs\n```