### PR TITLE
fix: possible leak on base64 decode failure

### DIFF
--- a/src/Parser.zig
+++ b/src/Parser.zig
@@ -314,6 +314,7 @@ inline fn parseOsc(input: []const u8, paste_allocator: ?std.mem.Allocator) !Resu
                 input[semicolon_idx + 3 .. sequence.len - 2];
             const decoder = std.base64.standard.Decoder;
             const text = try paste_allocator.?.alloc(u8, try decoder.calcSizeForSlice(payload));
+            errdefer paste_allocator.?.free(text);
             try decoder.decode(text, payload);
             log.debug("decoded paste: {s}", .{text});
             return .{


### PR DESCRIPTION
decoder.decode can fail on malformed base64 input after text has already been allocated, this adds an errdefer so the temporary allocation is released if decode fails before ownership transfer.

for repro I used a simple test to confirm the leak, I didn't add this to the pr so as not to bloat the test set:

test "parse: osc52 paste with malformed base64 does not leak" {
    const alloc = testing.allocator_instance.allocator();
    // "!!!!" is not valid base64; decode() will return error.InvalidCharacter
    const input = "\x1b]52;c;!!!!\x1b\\";
    var parser: Parser = .{};
    try testing.expectError(error.InvalidCharacter, parser.parse(input, alloc));
}