### PR TITLE
fix(vxfw): out of bounds panic on ScrollBars

### DIFF
--- a/src/vxfw/ScrollBars.zig
+++ b/src/vxfw/ScrollBars.zig
@@ -166,7 +166,7 @@ pub fn handleCapture(self: *ScrollBars, ctx: *vxfw.EventContext, event: vxfw.Eve
 
                     // If the new thumb position is at the top we know we've scrolled to the top of
                     // the scroll view.
-                    if (new_thumb_top == 0) {
+                    if (new_thumb_top <= 0) {
                         self.scroll_view.scroll.top = 0;
                         return ctx.consumeAndRedraw();
                     }
@@ -238,7 +238,7 @@ pub fn handleCapture(self: *ScrollBars, ctx: *vxfw.EventContext, event: vxfw.Eve
 
                     // If the new thumb position is at the horizontal beginning of the current view
                     // we know we've scrolled to the  beginning of the scroll view.
-                    if (new_thumb_col_start == 0) {
+                    if (new_thumb_col_start <= 0) {
                         self.scroll_view.scroll.left = 0;
                         return ctx.consumeAndRedraw();
                     }


### PR DESCRIPTION
Dragging a scrollbar with enough force and determination can cause `new_thumb_top` and `new_thumb_col_start` to be negative (both are `i16`), which causes an out of bounds panic when assigning to a `u32` on L194 and L254.