### PR TITLE
fix: prevent arena leak on allocation failure

### DIFF
--- a/src/InternalScreen.zig
+++ b/src/InternalScreen.zig
@@ -50,7 +50,9 @@ mouse_shape: MouseShape = .default,
 /// sets each cell to the default cell
 pub fn init(gpa: std.mem.Allocator, w: u16, h: u16) !InternalScreen {
     const arena = try gpa.create(std.heap.ArenaAllocator);
+    errdefer gpa.destroy(arena);
     arena.* = .init(gpa);
+    errdefer arena.deinit();
     var screen = InternalScreen{
         .arena = arena,
         .buf = try arena.allocator().alloc(InternalCell, @as(usize, @intCast(w)) * h),


### PR DESCRIPTION
The ArenaAllocator can be leaked if `.buf` allocation or `.initCapacity` fail, this fix adds errdefer paths to destroy the arena and deinitialize it so the arena struct and any allocated pages are freed on error.

Used the following test to reproduce the leak, I put it below for reference but thought it might not be necessary in the codebase itself.

```Zig
test "InternalScreen.init: allocation failure" {
    const Context = struct {
        fn run(allocator: std.mem.Allocator) !void {
            var screen = try InternalScreen.init(allocator, 10, 10);
            defer screen.deinit(allocator);
        }
    };

    try std.testing.checkAllAllocationFailures(
        std.testing.allocator,
        Context.run,
        .{},
    );
}
```